### PR TITLE
load prompt from file in spec

### DIFF
--- a/crates/baked_potato/tests/agent/fixtures/prompt.yaml
+++ b/crates/baked_potato/tests/agent/fixtures/prompt.yaml
@@ -1,0 +1,4 @@
+model: gpt-4o
+provider: OpenAI
+messages:
+  - "You are processing a DAG task from a prompt file."

--- a/crates/baked_potato/tests/agent/spec_test.rs
+++ b/crates/baked_potato/tests/agent/spec_test.rs
@@ -186,6 +186,53 @@ fn spec_loader_builds_dag_workflow_and_runs() {
 }
 
 #[test]
+fn spec_loader_dag_task_with_prompt_file_runs() {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let mut mock = LLMTestServer::new();
+    mock.start_server().unwrap();
+
+    let prompt_path = format!(
+        "{}/tests/agent/fixtures/prompt.yaml",
+        env!("CARGO_MANIFEST_DIR")
+    );
+
+    let yaml = format!(
+        r#"
+agents:
+  - id: worker
+    provider: openai
+    model: gpt-4o
+    max_iterations: 1
+workflows:
+  - id: dag
+    type: workflow
+    tasks:
+      - id: t1
+        agent: worker
+        prompt:
+          path: "{}"
+        dependencies: []
+"#,
+        prompt_path
+    );
+
+    let loaded = runtime
+        .block_on(async { SpecLoader::from_spec(&yaml).await })
+        .unwrap();
+
+    let prompt = Prompt::from_path(std::path::PathBuf::from(&prompt_path)).unwrap();
+    assert_eq!(prompt.model, "gpt-4o");
+    assert_eq!(prompt.provider, Provider::OpenAI);
+    assert!(!prompt.openai_messages().unwrap().messages.is_empty());
+
+    let wf = loaded.workflow("dag").expect("workflow 'dag' not found");
+    let result = runtime.block_on(async { wf.run(None).await });
+    assert!(result.is_ok());
+
+    mock.stop_server().unwrap();
+}
+
+#[test]
 fn spec_loader_dag_agent_missing_model_returns_error() {
     let runtime = tokio::runtime::Runtime::new().unwrap();
 

--- a/crates/baked_potato/tests/agent/spec_test.rs
+++ b/crates/baked_potato/tests/agent/spec_test.rs
@@ -233,6 +233,34 @@ workflows:
 }
 
 #[test]
+fn spec_loader_dag_task_prompt_file_not_found_returns_error() {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    let yaml = r#"
+agents:
+  - id: worker
+    provider: openai
+    model: gpt-4o
+    max_iterations: 1
+workflows:
+  - id: dag
+    type: workflow
+    tasks:
+      - id: t1
+        agent: worker
+        prompt:
+          path: "/nonexistent/path/prompt.yaml"
+        dependencies: []
+"#;
+
+    let result = runtime.block_on(async { SpecLoader::from_spec(yaml).await });
+    assert!(
+        matches!(result, Err(SpecError::PromptLoad { .. })),
+        "expected PromptLoad error for nonexistent prompt file"
+    );
+}
+
+#[test]
 fn spec_loader_dag_agent_missing_model_returns_error() {
     let runtime = tokio::runtime::Runtime::new().unwrap();
 

--- a/crates/baked_potato/tests/agent/spec_test.rs
+++ b/crates/baked_potato/tests/agent/spec_test.rs
@@ -87,11 +87,15 @@ fn spec_loader_builds_openai_agent_and_runs() {
         .block_on(async { SpecLoader::from_spec(SINGLE_AGENT_YAML).await })
         .unwrap();
 
-    let agent = loaded.agent("assistant").expect("agent 'assistant' not found");
+    let agent = loaded
+        .agent("assistant")
+        .expect("agent 'assistant' not found");
 
     let prompt_msg = OpenAIChatMessage {
         role: "user".to_string(),
-        content: vec![ContentPart::Text(TextContentPart::new("Hello!".to_string()))],
+        content: vec![ContentPart::Text(TextContentPart::new(
+            "Hello!".to_string(),
+        ))],
         name: None,
     };
     let prompt = Prompt::new_rs(
@@ -124,7 +128,9 @@ fn spec_loader_builds_sequential_workflow_and_runs() {
         .block_on(async { SpecLoader::from_spec(SEQUENTIAL_YAML).await })
         .unwrap();
 
-    let seq = loaded.sequential("pipeline").expect("sequential 'pipeline' not found");
+    let seq = loaded
+        .sequential("pipeline")
+        .expect("sequential 'pipeline' not found");
 
     let mut session = SessionState::new();
     let outcome = runtime
@@ -304,9 +310,8 @@ fn spec_loader_loads_agent_from_file() {
 fn spec_loader_file_not_found_returns_io_error() {
     let runtime = tokio::runtime::Runtime::new().unwrap();
 
-    let result = runtime.block_on(async {
-        SpecLoader::from_spec_path("/nonexistent/path/spec.yaml").await
-    });
+    let result =
+        runtime.block_on(async { SpecLoader::from_spec_path("/nonexistent/path/spec.yaml").await });
 
     assert!(
         matches!(result, Err(SpecError::Io(_))),

--- a/crates/baked_potato/tests/agent/spec_test.rs
+++ b/crates/baked_potato/tests/agent/spec_test.rs
@@ -292,6 +292,84 @@ workflows:
 }
 
 #[test]
+fn spec_loader_dag_file_prompt_agent_without_model_succeeds() {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let mut mock = LLMTestServer::new();
+    mock.start_server().unwrap();
+
+    let prompt_path = format!(
+        "{}/tests/agent/fixtures/prompt.yaml",
+        env!("CARGO_MANIFEST_DIR")
+    );
+
+    let yaml = format!(
+        r#"
+agents:
+  - id: no_model_agent
+    provider: openai
+    max_iterations: 1
+workflows:
+  - id: dag
+    type: workflow
+    tasks:
+      - id: t1
+        agent: no_model_agent
+        prompt:
+          path: "{}"
+        dependencies: []
+"#,
+        prompt_path
+    );
+
+    let loaded = runtime
+        .block_on(async { SpecLoader::from_spec(&yaml).await })
+        .unwrap();
+
+    let wf = loaded.workflow("dag").expect("workflow 'dag' not found");
+    let result = runtime.block_on(async { wf.run(None).await });
+    assert!(result.is_ok());
+
+    mock.stop_server().unwrap();
+}
+
+#[test]
+fn spec_loader_dag_file_prompt_provider_mismatch_returns_error() {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+
+    let prompt_path = format!(
+        "{}/tests/agent/fixtures/prompt.yaml",
+        env!("CARGO_MANIFEST_DIR")
+    );
+
+    // prompt.yaml specifies provider: OpenAI, but agent uses gemini
+    let yaml = format!(
+        r#"
+agents:
+  - id: gemini_agent
+    provider: gemini
+    model: gemini-2.0-flash
+    max_iterations: 1
+workflows:
+  - id: dag
+    type: workflow
+    tasks:
+      - id: t1
+        agent: gemini_agent
+        prompt:
+          path: "{}"
+        dependencies: []
+"#,
+        prompt_path
+    );
+
+    let result = runtime.block_on(async { SpecLoader::from_spec(&yaml).await });
+    assert!(
+        matches!(result, Err(SpecError::WorkflowBuild { .. })),
+        "expected WorkflowBuild error for provider mismatch"
+    );
+}
+
+#[test]
 fn spec_loader_loads_agent_from_file() {
     let runtime = tokio::runtime::Runtime::new().unwrap();
 

--- a/crates/potato_spec/src/error.rs
+++ b/crates/potato_spec/src/error.rs
@@ -19,4 +19,6 @@ pub enum SpecError {
     InvalidProvider { value: String, reason: String },
     #[error("workflow build error for '{id}': {reason}")]
     WorkflowBuild { id: String, reason: String },
+    #[error("failed to load prompt from '{path}': {reason}")]
+    PromptLoad { path: String, reason: String },
 }

--- a/crates/potato_spec/src/lib.rs
+++ b/crates/potato_spec/src/lib.rs
@@ -4,4 +4,4 @@ pub mod spec;
 
 pub use error::SpecError;
 pub use loader::{LoadedSpec, SpecLoader};
-pub use spec::PotatoSpec;
+pub use spec::{PotatoSpec, PromptRef};

--- a/crates/potato_spec/src/loader.rs
+++ b/crates/potato_spec/src/loader.rs
@@ -254,65 +254,80 @@ impl SpecLoader {
                     id: task_spec.agent.clone(),
                 })?;
 
-            let provider = agent.provider.clone();
-            let model = agent
-                .model_override
-                .clone()
-                .ok_or_else(|| SpecError::WorkflowBuild {
-                    id: task_spec.id.clone(),
-                    reason: format!(
-                        "agent '{}' used in task '{}' has no model set",
-                        task_spec.agent, task_spec.id
-                    ),
-                })?;
-
-            let prompt = match &task_spec.prompt {
-                PromptRef::Inline(text) => {
-                    let config_value = serde_json::json!({
-                        "model": model,
-                        "provider": provider.as_str(),
-                        "messages": [text],
-                    });
-                    let prompt_config = serde_json::from_value(config_value).map_err(|e| {
-                        SpecError::WorkflowBuild {
-                            id: task_spec.id.clone(),
-                            reason: e.to_string(),
-                        }
-                    })?;
-                    Prompt::from_generic_config(prompt_config).map_err(|e| {
-                        SpecError::WorkflowBuild {
-                            id: task_spec.id.clone(),
-                            reason: e.to_string(),
-                        }
-                    })?
-                }
-                PromptRef::File(path) => {
-                    if Path::new(path)
-                        .components()
-                        .any(|c| c == Component::ParentDir)
-                    {
-                        return Err(SpecError::PromptLoad {
-                            path: path.clone(),
-                            reason: "path must not contain '..' components".into(),
+            let prompt =
+                match &task_spec.prompt {
+                    PromptRef::Inline(text) => {
+                        let provider = agent.provider.clone();
+                        let model = agent.model_override.clone().ok_or_else(|| {
+                            SpecError::WorkflowBuild {
+                                id: task_spec.id.clone(),
+                                reason: format!(
+                                    "agent '{}' used in task '{}' has no model set",
+                                    task_spec.agent, task_spec.id
+                                ),
+                            }
+                        })?;
+                        let config_value = serde_json::json!({
+                            "model": model,
+                            "provider": provider.as_str(),
+                            "messages": [text],
                         });
-                    }
-                    let path_owned = path.clone();
-                    let task_id = task_spec.id.clone();
-                    tokio::task::spawn_blocking(move || {
-                        Prompt::from_path(PathBuf::from(&path_owned)).map_err(|e| {
-                            SpecError::PromptLoad {
-                                path: path_owned,
+                        let prompt_config = serde_json::from_value(config_value).map_err(|e| {
+                            SpecError::WorkflowBuild {
+                                id: task_spec.id.clone(),
                                 reason: e.to_string(),
                             }
+                        })?;
+                        Prompt::from_generic_config(prompt_config).map_err(|e| {
+                            SpecError::WorkflowBuild {
+                                id: task_spec.id.clone(),
+                                reason: e.to_string(),
+                            }
+                        })?
+                    }
+                    PromptRef::File(path) => {
+                        if Path::new(path)
+                            .components()
+                            .any(|c| c == Component::ParentDir)
+                        {
+                            return Err(SpecError::PromptLoad {
+                                path: path.clone(),
+                                reason: "path must not contain '..' components".into(),
+                            });
+                        }
+                        let path_owned = path.clone();
+                        let task_id = task_spec.id.clone();
+                        let agent_provider = agent.provider.clone();
+                        let prompt = tokio::task::spawn_blocking(move || {
+                            Prompt::from_path(PathBuf::from(&path_owned)).map_err(|e| {
+                                SpecError::PromptLoad {
+                                    path: path_owned,
+                                    reason: e.to_string(),
+                                }
+                            })
                         })
-                    })
-                    .await
-                    .map_err(|e| SpecError::WorkflowBuild {
-                        id: task_id,
-                        reason: format!("spawn_blocking failed: {e}"),
-                    })??
-                }
-            };
+                        .await
+                        .map_err(|e| SpecError::WorkflowBuild {
+                            id: task_id,
+                            reason: format!("spawn_blocking failed: {e}"),
+                        })??;
+
+                        if prompt.provider != agent_provider {
+                            return Err(SpecError::WorkflowBuild {
+                                id: task_spec.id.clone(),
+                                reason: format!(
+                                "prompt file '{}' specifies provider '{}' but agent '{}' uses '{}'",
+                                path,
+                                prompt.provider.as_str(),
+                                task_spec.agent,
+                                agent_provider.as_str(),
+                            ),
+                            });
+                        }
+
+                        prompt
+                    }
+                };
 
             let task = Task::new(
                 &agent.id,

--- a/crates/potato_spec/src/loader.rs
+++ b/crates/potato_spec/src/loader.rs
@@ -1,5 +1,5 @@
 use crate::error::SpecError;
-use crate::spec::{PromptRef, *};
+use crate::spec::*;
 use potato_agent::agents::{agent::Agent, runner::AgentRunner};
 use potato_agent::{
     AgentBuilder, AgentCallback, LoggingCallback, MergeStrategy, ParallelAgent,
@@ -8,7 +8,7 @@ use potato_agent::{
 use potato_type::{prompt::Prompt, tools::AsyncTool, Provider};
 use potato_workflow::{Task, Workflow};
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 pub(crate) fn topo_sort_tasks(tasks: &[TaskSpec]) -> Result<Vec<&TaskSpec>, SpecError> {
@@ -286,12 +286,27 @@ impl SpecLoader {
                     })?
                 }
                 PromptRef::File(path) => {
-                    Prompt::from_path(std::path::PathBuf::from(path)).map_err(|e| {
-                        SpecError::PromptLoad {
+                    if Path::new(path).components().any(|c| c == Component::ParentDir) {
+                        return Err(SpecError::PromptLoad {
                             path: path.clone(),
-                            reason: e.to_string(),
-                        }
-                    })?
+                            reason: "path must not contain '..' components".into(),
+                        });
+                    }
+                    let path_owned = path.clone();
+                    let task_id = task_spec.id.clone();
+                    tokio::task::spawn_blocking(move || {
+                        Prompt::from_path(PathBuf::from(&path_owned)).map_err(|e| {
+                            SpecError::PromptLoad {
+                                path: path_owned,
+                                reason: e.to_string(),
+                            }
+                        })
+                    })
+                    .await
+                    .map_err(|e| SpecError::WorkflowBuild {
+                        id: task_id,
+                        reason: format!("spawn_blocking failed: {e}"),
+                    })??
                 }
             };
 

--- a/crates/potato_spec/src/loader.rs
+++ b/crates/potato_spec/src/loader.rs
@@ -1,5 +1,5 @@
 use crate::error::SpecError;
-use crate::spec::*;
+use crate::spec::{PromptRef, *};
 use potato_agent::agents::{agent::Agent, runner::AgentRunner};
 use potato_agent::{
     AgentBuilder, AgentCallback, LoggingCallback, MergeStrategy, ParallelAgent,
@@ -266,23 +266,34 @@ impl SpecLoader {
                     ),
                 })?;
 
-            let config_value = serde_json::json!({
-                "model": model,
-                "provider": provider.as_str(),
-                "messages": [task_spec.prompt.clone()],
-            });
-            let prompt_config =
-                serde_json::from_value(config_value).map_err(|e| SpecError::WorkflowBuild {
-                    id: task_spec.id.clone(),
-                    reason: e.to_string(),
-                })?;
-
-            let prompt = Prompt::from_generic_config(prompt_config).map_err(|e| {
-                SpecError::WorkflowBuild {
-                    id: task_spec.id.clone(),
-                    reason: e.to_string(),
+            let prompt = match &task_spec.prompt {
+                PromptRef::Inline(text) => {
+                    let config_value = serde_json::json!({
+                        "model": model,
+                        "provider": provider.as_str(),
+                        "messages": [text],
+                    });
+                    let prompt_config =
+                        serde_json::from_value(config_value).map_err(|e| SpecError::WorkflowBuild {
+                            id: task_spec.id.clone(),
+                            reason: e.to_string(),
+                        })?;
+                    Prompt::from_generic_config(prompt_config).map_err(|e| {
+                        SpecError::WorkflowBuild {
+                            id: task_spec.id.clone(),
+                            reason: e.to_string(),
+                        }
+                    })?
                 }
-            })?;
+                PromptRef::File(path) => {
+                    Prompt::from_path(std::path::PathBuf::from(path)).map_err(|e| {
+                        SpecError::PromptLoad {
+                            path: path.clone(),
+                            reason: e.to_string(),
+                        }
+                    })?
+                }
+            };
 
             let task = Task::new(
                 &agent.id,
@@ -356,7 +367,7 @@ mod tests {
         TaskSpec {
             id: id.to_string(),
             agent: "x".to_string(),
-            prompt: "p".to_string(),
+            prompt: PromptRef::Inline("p".to_string()),
             dependencies: deps.into_iter().map(|s| s.to_string()).collect(),
             max_retries: None,
         }

--- a/crates/potato_spec/src/loader.rs
+++ b/crates/potato_spec/src/loader.rs
@@ -273,11 +273,12 @@ impl SpecLoader {
                         "provider": provider.as_str(),
                         "messages": [text],
                     });
-                    let prompt_config =
-                        serde_json::from_value(config_value).map_err(|e| SpecError::WorkflowBuild {
+                    let prompt_config = serde_json::from_value(config_value).map_err(|e| {
+                        SpecError::WorkflowBuild {
                             id: task_spec.id.clone(),
                             reason: e.to_string(),
-                        })?;
+                        }
+                    })?;
                     Prompt::from_generic_config(prompt_config).map_err(|e| {
                         SpecError::WorkflowBuild {
                             id: task_spec.id.clone(),
@@ -286,7 +287,10 @@ impl SpecLoader {
                     })?
                 }
                 PromptRef::File(path) => {
-                    if Path::new(path).components().any(|c| c == Component::ParentDir) {
+                    if Path::new(path)
+                        .components()
+                        .any(|c| c == Component::ParentDir)
+                    {
                         return Err(SpecError::PromptLoad {
                             path: path.clone(),
                             reason: "path must not contain '..' components".into(),
@@ -390,10 +394,7 @@ mod tests {
 
     #[test]
     fn test_topo_sort_out_of_order() {
-        let tasks = vec![
-            make_task("t2", vec!["t1"]),
-            make_task("t1", vec![]),
-        ];
+        let tasks = vec![make_task("t2", vec!["t1"]), make_task("t1", vec![])];
         let sorted = topo_sort_tasks(&tasks).unwrap();
         assert_eq!(sorted.len(), 2);
         assert_eq!(sorted[0].id, "t1");
@@ -402,10 +403,7 @@ mod tests {
 
     #[test]
     fn test_topo_sort_cycle_returns_error() {
-        let tasks = vec![
-            make_task("a", vec!["b"]),
-            make_task("b", vec!["a"]),
-        ];
+        let tasks = vec![make_task("a", vec!["b"]), make_task("b", vec!["a"])];
         let result = topo_sort_tasks(&tasks);
         assert!(result.is_err());
         match result.unwrap_err() {

--- a/crates/potato_spec/src/spec.rs
+++ b/crates/potato_spec/src/spec.rs
@@ -1,5 +1,40 @@
 use serde::Deserialize;
 
+#[derive(Debug, Clone)]
+pub enum PromptRef {
+    Inline(String),
+    File(String),
+}
+
+impl<'de> Deserialize<'de> for PromptRef {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        use serde::de::{self, Visitor};
+        struct V;
+        impl<'de> Visitor<'de> for V {
+            type Value = PromptRef;
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "a string or a map with a 'path' key")
+            }
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                Ok(PromptRef::Inline(v.to_owned()))
+            }
+            fn visit_map<A: de::MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+                let mut path: Option<String> = None;
+                while let Some(key) = map.next_key::<String>()? {
+                    if key == "path" {
+                        path = Some(map.next_value()?);
+                    } else {
+                        map.next_value::<serde::de::IgnoredAny>()?;
+                    }
+                }
+                path.map(PromptRef::File)
+                    .ok_or_else(|| de::Error::missing_field("path"))
+            }
+        }
+        d.deserialize_any(V)
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct PotatoSpec {
     #[serde(default)]
@@ -107,7 +142,7 @@ pub enum MergeStrategySpec {
 pub struct TaskSpec {
     pub id: String,
     pub agent: String,
-    pub prompt: String,
+    pub prompt: PromptRef,
     #[serde(default)]
     pub dependencies: Vec<String>,
     pub max_retries: Option<u32>,

--- a/crates/potato_spec/src/spec.rs
+++ b/crates/potato_spec/src/spec.rs
@@ -147,3 +147,29 @@ pub struct TaskSpec {
     pub dependencies: Vec<String>,
     pub max_retries: Option<u32>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_ref_deserializes_from_string() {
+        let yaml = "\"hello world\"";
+        let p: PromptRef = serde_yaml::from_str(yaml).unwrap();
+        assert!(matches!(p, PromptRef::Inline(s) if s == "hello world"));
+    }
+
+    #[test]
+    fn prompt_ref_deserializes_from_path_map() {
+        let yaml = "path: ./prompts/foo.yaml";
+        let p: PromptRef = serde_yaml::from_str(yaml).unwrap();
+        assert!(matches!(p, PromptRef::File(s) if s == "./prompts/foo.yaml"));
+    }
+
+    #[test]
+    fn prompt_ref_map_missing_path_returns_error() {
+        let yaml = "other_key: value";
+        let result: Result<PromptRef, _> = serde_yaml::from_str(yaml);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
# Pull Request

### Short Summary

Adds `PromptRef` to `SpecLoader`, letting DAG task specs reference a prompt YAML file instead of an inline string. The `prompt` field in a `TaskSpec` now accepts either `"some text"` (existing behavior, unchanged) or `{ path: "./path/to/prompt.yaml" }`. File loading is async-safe via `spawn_blocking`, with basic path traversal rejection.

### Context

Previously, `TaskSpec.prompt` was a plain `String` — always treated as an inline message. There was no way to point a workflow task at an existing prompt file, even though `Prompt::from_path` already supported loading `.yaml`/`.json` prompt definitions with full provider config, settings, and variable parameters.

**`PromptRef` deserialization** — a custom serde `Visitor` dispatches on value type: a YAML scalar becomes `Inline(String)`, a mapping with a `path` key becomes `File(String)`. This is entirely backwards-compatible; no existing YAML spec needs to change.

**Before:**
```yaml
tasks:
  - id: t1
    agent: worker
    prompt: "Summarize the following text."
```

**After (both forms valid):**
```yaml
tasks:
  - id: t1
    agent: worker
    prompt: "Summarize the following text."   # unchanged

  - id: t2
    agent: worker
    prompt:
      path: "./prompts/summarize.yaml"         # new
```

**Async safety** — `Prompt::from_path` calls `std::fs::read_to_string` synchronously. Since `build_workflow` is `async`, wrapping in `tokio::task::spawn_blocking` keeps the blocking syscall off the runtime worker threads.

**Path safety** — paths containing `..` components are rejected at the loader level before any I/O. Full canonicalization/sandboxing is intentionally deferred; `SpecLoader` is developer-facing and not exposed to untrusted user input.

**New error variant** — `SpecError::PromptLoad { path, reason }` distinguishes prompt file load failures from general workflow build errors.

| File | Change |
|---|---|
| `crates/potato_spec/src/spec.rs` | Adds `PromptRef` enum with custom `Deserialize`; changes `TaskSpec.prompt: String` → `TaskSpec.prompt: PromptRef`; adds 3 unit tests for deser branches |
| `crates/potato_spec/src/loader.rs` | `build_workflow` branches on `PromptRef`; `File` arm uses `spawn_blocking` + `..` rejection |
| `crates/potato_spec/src/error.rs` | Adds `PromptLoad { path, reason }` variant |
| `crates/potato_spec/src/lib.rs` | Re-exports `PromptRef` |
| `crates/baked_potato/tests/agent/spec_test.rs` | Adds 2 integration tests: happy path (file prompt runs end-to-end) and error path (nonexistent file → `SpecError::PromptLoad`) |
| `crates/baked_potato/tests/agent/fixtures/prompt.yaml` | New OpenAI prompt fixture used by the integration test |

### Is this a Breaking Change?

No. The `prompt` field previously held a `String`; all existing YAML specs with `prompt: "text"` deserialize to `PromptRef::Inline("text")` and follow the same code path as before. The only public API addition is `PromptRef` itself and `SpecError::PromptLoad`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/demml/potatohead/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
