### PR TITLE
bump pyo3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "baked-potato"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1637,7 +1637,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potato-agent"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "potato-head"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "baked-potato",
  "potato-agent",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "potato-provider"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "base64",
  "gcloud-auth",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "potato-spec"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "potato-agent",
  "potato-type",
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "potato-state"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "thiserror 2.0.18",
  "tokio",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "potato-type"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "async-trait",
  "potato-util",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "potato-util"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "colored_json",
  "pyo3",
@@ -1753,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "potato-workflow"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "potato-agent",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "potatohead-macro"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "py-potatohead"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "potato-head",
  "pyo3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assert-json-diff"
@@ -90,9 +90,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -163,9 +163,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]
@@ -187,9 +187,9 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytecount"
@@ -211,9 +211,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -241,9 +241,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -255,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -306,16 +306,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "core-foundation"
@@ -410,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -515,16 +505,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "etcetera"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,12 +536,6 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
@@ -610,21 +584,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,9 +610,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -661,15 +620,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -689,15 +648,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -706,21 +665,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -729,22 +688,21 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
 [[package]]
 name = "gcloud-auth"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bdedbc36e6b9d8d79558fbf2ebc098745bc721e9d37d3e369558e420038e360"
+checksum = "b43924e3df02cb3b846ca66a7ee58e8c13eb2556d0308c71f6154083f6980365"
 dependencies = [
  "async-trait",
  "base64",
  "gcloud-metadata",
  "home",
  "jsonwebtoken",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -757,11 +715,11 @@ dependencies = [
 
 [[package]]
 name = "gcloud-metadata"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f706788c1b58712c513e4d403234707fd255f49caa89d1c930197418b5fb2c"
+checksum = "bd3152612316be627be52fe9ca72331eb48425059b3a6a700e7adde223e061d5"
 dependencies = [
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "thiserror 2.0.18",
  "tokio",
 ]
@@ -798,20 +756,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -856,6 +814,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -952,9 +916,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -967,7 +931,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -989,22 +952,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -1056,12 +1003,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1069,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1082,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1096,15 +1044,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1116,15 +1064,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1164,36 +1112,27 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1201,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -1214,7 +1153,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1223,9 +1162,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -1239,19 +1200,21 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jsonschema"
-version = "0.41.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9320368abda84a3aad44953d61e70515681fe43ae94529dff5567e0215b88438"
+checksum = "257eb0e588b76827bbddc9e73945a9743693dd2adeaee9da26420f93cfedb798"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1310,9 +1273,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libm"
@@ -1322,14 +1285,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1344,16 +1307,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
-
-[[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1393,15 +1350,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1451,23 +1399,6 @@ dependencies = [
  "serde_urlencoded",
  "similar",
  "tokio",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe 0.1.6",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1536,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -1583,59 +1514,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "outref"
@@ -1645,9 +1532,9 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking"
@@ -1705,15 +1592,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs1"
@@ -1898,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1950,38 +1831,35 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
  "anyhow",
  "chrono",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
  "serde",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1989,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2001,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2014,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "pythonize"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a8f29db331e28c332c63496cfcbb822aca3d7320bc08b655d7fd0c29c50ede"
+checksum = "0b79f670c9626c8b651c0581011b57b6ba6970bb69faf01a7c4c0cfc81c43f95"
 dependencies = [
  "pyo3",
  "serde",
@@ -2044,10 +1922,11 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -2079,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2091,6 +1970,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2162,9 +2047,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -2191,9 +2076,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.41.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5773259506800a8c6ef38df3674b061c62c5941162507891ff8b580e93d954e"
+checksum = "e2f38748ceca8d0b0013e60f534d94a6e23dfd89fd2a88318fc5a2d04fda1010"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -2229,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -2241,7 +2126,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -2250,13 +2134,10 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "mime_guess",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2268,7 +2149,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -2290,6 +2170,7 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -2302,13 +2183,16 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -2357,29 +2241,17 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
-name = "rustix"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
-]
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2394,10 +2266,10 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.5.1",
+ "security-framework",
 ]
 
 [[package]]
@@ -2416,7 +2288,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
@@ -2425,7 +2297,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.5.1",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -2439,10 +2311,11 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -2490,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2530,25 +2403,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
-dependencies = [
- "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2556,9 +2416,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2566,9 +2426,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2704,9 +2564,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -2731,12 +2591,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2971,9 +2831,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3002,22 +2862,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
-
-[[package]]
-name = "tempfile"
-version = "3.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
-dependencies = [
- "fastrand",
- "getrandom 0.4.1",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
-]
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "thiserror"
@@ -3101,9 +2948,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3111,9 +2958,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3135,9 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -3151,23 +2998,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -3317,9 +3154,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "nu-ansi-term",
  "serde",
@@ -3365,9 +3202,9 @@ checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -3389,12 +3226,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -3440,11 +3271,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -3534,9 +3365,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3547,23 +3378,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3571,9 +3398,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3584,9 +3411,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -3640,9 +3467,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4132,9 +3959,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yansi"
@@ -4144,9 +3971,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4155,9 +3982,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4167,18 +3994,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4187,18 +4014,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4214,9 +4041,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4225,9 +4052,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4236,9 +4063,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4247,6 +4074,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,23 +9,23 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.20.0"
+version = "0.21.0"
 authors = ["demml <support@demmlai.com>"]
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/demml/potatohead"
 
 [workspace.dependencies]
-baked-potato = { path = "crates/baked_potato", version = "0.20.0" }
-potato-agent = { path = "crates/potato_agent", version = "0.20.0" }
-potato-provider = { path = "crates/potato_provider", version = "0.20.0" }
-potatohead-macro = { path = "crates/potato_macro", version = "0.20.0" }
-potato-type = { path = "crates/potato_type", version = "0.20.0" }
-potato-workflow = { path = "crates/potato_workflow", version = "0.20.0" }
-potato-util = { path = "crates/potato_util", version = "0.20.0" }
-potato-head = { path = "crates/potato_head", version = "0.20.0" }
-potato-state = { path = "crates/potato_state", version = "0.20.0" }
-potato-spec = { path = "crates/potato_spec", version = "0.20.0" }
+baked-potato = { path = "crates/baked_potato", version = "0.21.0" }
+potato-agent = { path = "crates/potato_agent", version = "0.21.0" }
+potato-provider = { path = "crates/potato_provider", version = "0.21.0" }
+potatohead-macro = { path = "crates/potato_macro", version = "0.21.0" }
+potato-type = { path = "crates/potato_type", version = "0.21.0" }
+potato-workflow = { path = "crates/potato_workflow", version = "0.21.0" }
+potato-util = { path = "crates/potato_util", version = "0.21.0" }
+potato-head = { path = "crates/potato_head", version = "0.21.0" }
+potato-state = { path = "crates/potato_state", version = "0.21.0" }
+potato-spec = { path = "crates/potato_spec", version = "0.21.0" }
 
 anyhow = "1.0.93"
 async-trait = "0.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ colored_json = "5.*"
 http = "1.*"
 gcloud-auth = { version = "1.*" }
 mockito = "1.*"
-pyo3 = { version = "0.27.2", features = ["abi3-py310", "extension-module", "anyhow", "serde", "chrono"] }
+pyo3 = { version = "0.28.*", features = ["abi3-py310", "extension-module", "anyhow", "serde", "chrono"] }
 pythonize = { version = "0.*" }
 rand = "0.9.*"
 regex = "1.*"

--- a/crates/baked_potato/src/mock.rs
+++ b/crates/baked_potato/src/mock.rs
@@ -487,7 +487,7 @@ impl Default for LLMApiMock {
     }
 }
 
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 #[allow(dead_code)]
 pub struct LLMTestServer {
     openai_server: Option<LLMApiMock>,

--- a/crates/potato_agent/src/agents/agent.rs
+++ b/crates/potato_agent/src/agents/agent.rs
@@ -921,7 +921,7 @@ impl<'de> Deserialize<'de> for Agent {
     }
 }
 
-#[pyclass(name = "Agent")]
+#[pyclass(from_py_object, name = "Agent")]
 #[derive(Debug, Clone)]
 pub struct PyAgent {
     pub agent: Arc<Agent>,

--- a/crates/potato_agent/src/agents/task.rs
+++ b/crates/potato_agent/src/agents/task.rs
@@ -6,7 +6,7 @@ use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::{error, instrument};
-#[pyclass(eq)]
+#[pyclass(from_py_object)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum TaskStatus {
     Pending,
@@ -15,7 +15,7 @@ pub enum TaskStatus {
     Failed,
 }
 
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 #[derive(Debug, Serialize)]
 pub struct WorkflowTask {
     #[pyo3(get)]
@@ -51,7 +51,7 @@ impl WorkflowTask {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Task {
     #[pyo3(get)]

--- a/crates/potato_agent/src/agents/task.rs
+++ b/crates/potato_agent/src/agents/task.rs
@@ -6,7 +6,7 @@ use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::{error, instrument};
-#[pyclass(from_py_object)]
+#[pyclass(from_py_object, eq)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum TaskStatus {
     Pending,

--- a/crates/potato_agent/src/agents/types.rs
+++ b/crates/potato_agent/src/agents/types.rs
@@ -52,7 +52,7 @@ impl AgentResponse {
     }
 }
 
-#[pyclass(name = "AgentResponse")]
+#[pyclass(skip_from_py_object, name = "AgentResponse")]
 #[derive(Debug, Serialize)]
 pub struct PyAgentResponse {
     pub inner: AgentResponse,

--- a/crates/potato_provider/src/providers/embed.rs
+++ b/crates/potato_provider/src/providers/embed.rs
@@ -251,7 +251,7 @@ impl EmbeddingResponse {
     }
 }
 
-#[pyclass(name = "Embedder")]
+#[pyclass(from_py_object, name = "Embedder")]
 #[derive(Debug, Clone)]
 pub struct PyEmbedder {
     pub embedder: Arc<Embedder>,

--- a/crates/potato_type/src/anthropic/v1/request.rs
+++ b/crates/potato_type/src/anthropic/v1/request.rs
@@ -48,7 +48,7 @@ pub const SEARCH_RESULT_LOCATION_TYPE: &str = "search_result_location";
 pub const WEB_SEARCH_TOOL_RESULT_ERROR_TYPE: &str = "web_search_tool_result_error";
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct CitationCharLocationParam {
     #[pyo3(get, set)]
     pub cited_text: String,
@@ -87,7 +87,7 @@ impl CitationCharLocationParam {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct CitationPageLocationParam {
     #[pyo3(get, set)]
     pub cited_text: String,
@@ -126,7 +126,7 @@ impl CitationPageLocationParam {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct CitationContentBlockLocationParam {
     #[pyo3(get, set)]
     pub cited_text: String,
@@ -165,7 +165,7 @@ impl CitationContentBlockLocationParam {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct CitationWebSearchResultLocationParam {
     #[pyo3(get, set)]
     pub cited_text: String,
@@ -195,7 +195,7 @@ impl CitationWebSearchResultLocationParam {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct CitationSearchResultLocationParam {
     #[pyo3(get, set)]
     pub cited_text: String,
@@ -249,7 +249,7 @@ pub enum TextCitationParam {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct TextBlockParam {
     #[pyo3(get, set)]
     pub text: String,
@@ -329,7 +329,7 @@ impl TextBlockParam {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct Base64ImageSource {
     #[pyo3(get, set)]
     pub media_type: String,
@@ -357,7 +357,7 @@ impl Base64ImageSource {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct UrlImageSource {
     #[pyo3(get, set)]
     pub url: String,
@@ -385,7 +385,7 @@ pub enum ImageSource {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ImageBlockParam {
     pub source: ImageSource,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -432,7 +432,7 @@ impl ImageBlockParam {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct Base64PDFSource {
     #[pyo3(get, set)]
     pub media_type: String,
@@ -456,7 +456,7 @@ impl Base64PDFSource {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct UrlPDFSource {
     #[pyo3(get, set)]
     pub url: String,
@@ -477,7 +477,7 @@ impl UrlPDFSource {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct PlainTextSource {
     #[pyo3(get, set)]
     pub media_type: String,
@@ -501,7 +501,7 @@ impl PlainTextSource {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct CitationsConfigParams {
     #[pyo3(get, set)]
     pub enabled: Option<bool>,
@@ -516,7 +516,7 @@ pub enum DocumentSource {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct DocumentBlockParam {
     pub source: DocumentSource,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -567,7 +567,7 @@ impl DocumentBlockParam {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct SearchResultBlockParam {
     #[pyo3(get, set)]
     pub content: Vec<TextBlockParam>,
@@ -607,7 +607,7 @@ impl SearchResultBlockParam {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ThinkingBlockParam {
     #[pyo3(get, set)]
     pub thinking: String,
@@ -632,7 +632,7 @@ impl ThinkingBlockParam {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct RedactedThinkingBlockParam {
     #[pyo3(get, set)]
     pub data: String,
@@ -653,7 +653,7 @@ impl RedactedThinkingBlockParam {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ToolUseBlockParam {
     #[pyo3(get, set)]
     pub id: String,
@@ -705,7 +705,7 @@ pub enum ToolResultContentEnum {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ToolResultBlockParam {
     #[pyo3(get, set)]
     pub tool_use_id: String,
@@ -822,7 +822,7 @@ impl ToolResultBlockParam {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ServerToolUseBlockParam {
     #[pyo3(get, set)]
     pub id: String,
@@ -863,7 +863,7 @@ impl ServerToolUseBlockParam {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct WebSearchResultBlockParam {
     #[pyo3(get, set)]
     pub encrypted_content: String,
@@ -899,7 +899,7 @@ impl WebSearchResultBlockParam {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct WebSearchToolResultBlockParam {
     #[pyo3(get, set)]
     pub tool_use_id: String,
@@ -1156,7 +1156,7 @@ impl ContentBlockParam {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct MessageParam {
     pub content: Vec<ContentBlockParam>,
     #[pyo3(get)]
@@ -1417,7 +1417,7 @@ impl MessageConversion for MessageParam {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct Metadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_id: Option<String>,
@@ -1433,7 +1433,7 @@ impl Metadata {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct CacheControl {
     #[serde(rename = "type")]
     pub cache_type: String, // "ephemeral"
@@ -1451,7 +1451,7 @@ impl CacheControl {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass(name = "AnthropicTool")]
+#[pyclass(from_py_object, name = "AnthropicTool")]
 pub struct Tool {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1497,7 +1497,7 @@ impl Tool {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass(name = "AnthropicThinkingConfig")]
+#[pyclass(from_py_object, name = "AnthropicThinkingConfig")]
 pub struct ThinkingConfig {
     #[pyo3(get)]
     pub r#type: String,
@@ -1520,7 +1520,7 @@ impl ThinkingConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass(name = "AnthropicToolChoice")]
+#[pyclass(from_py_object, name = "AnthropicToolChoice")]
 pub struct ToolChoice {
     #[pyo3(get)]
     pub r#type: String, // "auto", "any", "tool", "none"
@@ -1566,7 +1566,7 @@ impl ToolChoice {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 #[serde(default)]
 pub struct AnthropicSettings {
     #[pyo3(get)]
@@ -1829,7 +1829,7 @@ impl RequestAdapter for AnthropicMessageRequestV1 {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct SystemPrompt {
     #[pyo3(get)]
     #[serde(flatten)]

--- a/crates/potato_type/src/anthropic/v1/response.rs
+++ b/crates/potato_type/src/anthropic/v1/response.rs
@@ -10,7 +10,7 @@ use pyo3::IntoPyObjectExt;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct CitationCharLocation {
     #[pyo3(get, set)]
     pub cited_text: String,
@@ -30,7 +30,7 @@ pub struct CitationCharLocation {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct CitationPageLocation {
     #[pyo3(get, set)]
     pub cited_text: String,
@@ -50,7 +50,7 @@ pub struct CitationPageLocation {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct CitationContentBlockLocation {
     #[pyo3(get, set)]
     pub cited_text: String,
@@ -70,7 +70,7 @@ pub struct CitationContentBlockLocation {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct CitationsWebSearchResultLocation {
     #[pyo3(get, set)]
     pub cited_text: String,
@@ -86,7 +86,7 @@ pub struct CitationsWebSearchResultLocation {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct CitationsSearchResultLocation {
     #[pyo3(get, set)]
     pub cited_text: String,
@@ -118,7 +118,7 @@ pub enum TextCitation {
 
 /// Text block in response content with citations
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct TextBlock {
     #[pyo3(get, set)]
     pub text: String,
@@ -156,7 +156,7 @@ impl TextBlock {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ThinkingBlock {
     #[pyo3(get, set)]
     pub thinking: String,
@@ -168,7 +168,7 @@ pub struct ThinkingBlock {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct RedactedThinkingBlock {
     #[pyo3(get, set)]
     pub data: String,
@@ -178,7 +178,7 @@ pub struct RedactedThinkingBlock {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ToolUseBlock {
     #[pyo3(get, set)]
     pub id: String,
@@ -191,7 +191,7 @@ pub struct ToolUseBlock {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ServerToolUseBlock {
     #[pyo3(get, set)]
     pub id: String,
@@ -204,7 +204,7 @@ pub struct ServerToolUseBlock {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct WebSearchResultBlock {
     #[pyo3(get, set)]
     pub encrypted_content: String,
@@ -220,7 +220,7 @@ pub struct WebSearchResultBlock {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct WebSearchToolResultError {
     #[pyo3(get, set)]
     pub error_code: String,
@@ -238,7 +238,7 @@ pub enum WebSearchToolResultBlockContent {
 
 /// Web search tool result block
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct WebSearchToolResultBlock {
     pub content: WebSearchToolResultBlockContent,
     #[pyo3(get, set)]
@@ -322,7 +322,7 @@ impl MessageResponseExt for ResponseContentBlock {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum StopReason {
     EndTurn,
     MaxTokens,
@@ -331,7 +331,7 @@ pub enum StopReason {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass(name = "AnthropicUsage")]
+#[pyclass(skip_from_py_object, name = "AnthropicUsage")]
 pub struct Usage {
     #[pyo3(get)]
     pub input_tokens: i32,
@@ -348,7 +348,7 @@ pub struct Usage {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct AnthropicMessageResponse {
     #[pyo3(get)]
     pub id: String,

--- a/crates/potato_type/src/google/v1/embedding/mod.rs
+++ b/crates/potato_type/src/google/v1/embedding/mod.rs
@@ -12,7 +12,7 @@ use pythonize::{depythonize, pythonize};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 #[serde(rename_all = "camelCase", default)]
 pub struct PredictRequest {
     pub instances: Value,
@@ -52,7 +52,7 @@ impl PredictRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 #[serde(rename_all = "camelCase", default)]
 pub struct PredictResponse {
     pub predictions: Value,
@@ -301,7 +301,7 @@ mod tests {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[pyclass(eq, eq_int)]
+#[pyclass(from_py_object, eq, eq_int)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum EmbeddingTaskType {
     TaskTypeUnspecified,
@@ -316,7 +316,7 @@ pub enum EmbeddingTaskType {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct GeminiEmbeddingConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
@@ -385,7 +385,7 @@ impl EmbeddingConfigTrait for GeminiEmbeddingConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ContentEmbedding {
     pub values: Vec<f32>,
 }
@@ -399,7 +399,7 @@ impl ContentEmbedding {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct GeminiEmbeddingResponse {
     #[pyo3(get)]
     pub embedding: ContentEmbedding,

--- a/crates/potato_type/src/google/v1/generate/adk_response.rs
+++ b/crates/potato_type/src/google/v1/generate/adk_response.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// Python-accessible tool call info — returned from `AdkLlmResponse.get_tool_calls()`.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Clone)]
 pub struct AdkToolCallInfo {
@@ -30,7 +30,7 @@ pub struct AdkToolCallInfo {
 /// ADK Part — uses individual Option fields to handle Pydantic's wire format which
 /// serializes ALL fields including null values (e.g. `"function_call": null`).
 /// A flattened enum cannot handle this; individual Option<T> fields can.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 #[serde(rename_all = "snake_case", default)]
@@ -68,7 +68,7 @@ impl AdkPart {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct AdkContent {
@@ -76,7 +76,7 @@ pub struct AdkContent {
     pub role: String,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -99,7 +99,7 @@ pub struct AdkUsageMetadata {
     pub traffic_type: Option<TrafficType>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -108,7 +108,7 @@ pub struct AdkTranscription {
     pub finished: Option<bool>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -121,7 +121,7 @@ pub struct AdkCacheMetadata {
     pub created_at: Option<f64>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -133,7 +133,7 @@ pub struct AdkLiveSessionResumptionUpdate {
 
 /// Google ADK `LlmResponse` — flat, snake_case structure.
 /// Discriminator: presence of the `"partial"` key (ADK-specific).
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct AdkLlmResponse {

--- a/crates/potato_type/src/google/v1/generate/request.rs
+++ b/crates/potato_type/src/google/v1/generate/request.rs
@@ -33,7 +33,7 @@ use pythonize::depythonize;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum SchemaType {
     TypeUnspecified,
     String,
@@ -47,7 +47,7 @@ pub enum SchemaType {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct Schema {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "type")]
@@ -184,7 +184,7 @@ impl Schema {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum HarmCategory {
@@ -203,7 +203,7 @@ pub enum HarmCategory {
 }
 
 /// Probability-based threshold levels for blocking.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum HarmBlockThreshold {
@@ -219,7 +219,7 @@ pub enum HarmBlockThreshold {
 /// Specifies whether the threshold is used for probability or severity score.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum HarmBlockMethod {
     HarmBlockMethodUnspecified,
     Severity,
@@ -229,7 +229,7 @@ pub enum HarmBlockMethod {
 /// Safety settings for harm blocking.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct SafetySetting {
     /// Required. The harm category.
     #[pyo3(get)]
@@ -251,7 +251,7 @@ impl SafetySetting {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Modality {
@@ -265,7 +265,7 @@ pub enum Modality {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum MediaResolution {
     MediaResolutionUnspecified,
     MediaResolutionLow,
@@ -275,7 +275,7 @@ pub enum MediaResolution {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum ModelRoutingPreference {
     Unknown,
     PrioritizeQuality,
@@ -285,7 +285,7 @@ pub enum ModelRoutingPreference {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum ThinkingLevel {
     ThinkingLevelUnspecified,
     Low,
@@ -294,7 +294,7 @@ pub enum ThinkingLevel {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass(name = "GeminiThinkingConfig")]
+#[pyclass(from_py_object, name = "GeminiThinkingConfig")]
 pub struct ThinkingConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub include_thoughts: Option<bool>,
@@ -323,7 +323,7 @@ impl ThinkingConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass(name = "ImageConfig")]
+#[pyclass(from_py_object, name = "ImageConfig")]
 pub struct ImageConfig {
     pub aspect_ratio: Option<String>,
     pub image_size: Option<String>,
@@ -343,7 +343,7 @@ impl ImageConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct AutoRoutingMode {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model_routing_preference: Option<ModelRoutingPreference>,
@@ -362,7 +362,7 @@ impl AutoRoutingMode {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ManualRoutingMode {
     pub model_name: String,
 }
@@ -378,7 +378,7 @@ impl ManualRoutingMode {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum RoutingConfigMode {
     AutoMode(AutoRoutingMode),
     ManualMode(ManualRoutingMode),
@@ -402,7 +402,7 @@ impl RoutingConfigMode {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct RoutingConfig {
     #[serde(flatten)]
     pub routing_config: RoutingConfigMode,
@@ -418,7 +418,7 @@ impl RoutingConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct PrebuiltVoiceConfig {
     pub voice_name: String,
 }
@@ -433,7 +433,7 @@ impl PrebuiltVoiceConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct VoiceConfig {
     pub prebuilt_voice_config: PrebuiltVoiceConfig,
 }
@@ -450,7 +450,7 @@ impl VoiceConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct SpeakerVoiceConfig {
     pub speaker: String,
     pub voice_config: VoiceConfig,
@@ -469,7 +469,7 @@ impl SpeakerVoiceConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct MultiSpeakerVoiceConfig {
     pub speaker_voice_configs: Vec<SpeakerVoiceConfig>,
 }
@@ -486,7 +486,7 @@ impl MultiSpeakerVoiceConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct SpeechConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub voice_config: Option<VoiceConfig>,
@@ -515,7 +515,7 @@ impl SpeechConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct GenerationConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[pyo3(get)]
@@ -660,7 +660,7 @@ impl GenerationConfig {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct ModelArmorConfig {
@@ -685,7 +685,7 @@ impl ModelArmorConfig {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Mode {
@@ -698,7 +698,7 @@ pub enum Mode {
     None,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct FunctionCallingConfig {
@@ -720,7 +720,7 @@ impl FunctionCallingConfig {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct LatLng {
@@ -741,7 +741,7 @@ impl LatLng {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct RetrievalConfig {
@@ -763,7 +763,7 @@ impl RetrievalConfig {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct ToolConfig {
@@ -788,7 +788,7 @@ impl ToolConfig {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 pub struct GeminiSettings {
     #[pyo3(get)]
@@ -908,7 +908,7 @@ impl GeminiSettings {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Language {
@@ -916,7 +916,7 @@ pub enum Language {
     Python,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Outcome {
@@ -926,7 +926,7 @@ pub enum Outcome {
     OutcomeDeadlineExceeded,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 pub struct FileData {
@@ -939,7 +939,7 @@ pub struct FileData {
     pub display_name: Option<String>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 pub struct PartialArgs {
     pub json_path: String,
@@ -978,7 +978,7 @@ impl PartialArgs {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 pub struct FunctionCall {
     /// Required. The name of the function to call.
@@ -1026,7 +1026,7 @@ impl FunctionCall {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 pub struct Blob {
@@ -1038,7 +1038,7 @@ pub struct Blob {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
 }
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 pub struct FunctionResponse {
     /// Required. The name of the function that was called.
@@ -1047,7 +1047,7 @@ pub struct FunctionResponse {
     pub response: HashMap<String, Value>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -1058,7 +1058,7 @@ pub struct ExecutableCode {
     pub code: String,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -1070,7 +1070,7 @@ pub struct CodeExecutionResult {
     pub output: Option<String>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -1083,7 +1083,7 @@ pub struct VideoMetadata {
     pub end_offset: Option<String>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
 pub struct PartMetadata {
@@ -1176,7 +1176,7 @@ fn extract_data_from_py_object(data: &Bound<'_, PyAny>) -> Result<DataNum, TypeE
     ))
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Part {
@@ -1257,7 +1257,7 @@ impl Part {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct GeminiContent {
@@ -1545,7 +1545,7 @@ impl MessageConversion for GeminiContent {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Behavior {
     #[default]
@@ -1555,7 +1555,7 @@ pub enum Behavior {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 #[serde(rename_all = "camelCase", default)]
 pub struct FunctionDeclaration {
     pub name: String,
@@ -1574,7 +1574,7 @@ pub struct FunctionDeclaration {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct DataStoreSpec {
     pub data_store: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1591,7 +1591,7 @@ impl DataStoreSpec {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct VertexAISearch {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub datastore: Option<String>,
@@ -1629,7 +1629,7 @@ impl VertexAISearch {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct VertexRagStore {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rag_resources: Option<Vec<RagResource>>,
@@ -1643,7 +1643,7 @@ pub struct VertexRagStore {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct RagResource {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rag_corpus: Option<String>,
@@ -1665,7 +1665,7 @@ impl RagResource {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct RagRetrievalConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub top_k: Option<i32>,
@@ -1690,7 +1690,7 @@ impl RagRetrievalConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct Filter {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata_filter: Option<String>,
@@ -1719,7 +1719,7 @@ impl Filter {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct RankService {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model_name: Option<String>,
@@ -1736,7 +1736,7 @@ impl RankService {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct LlmRanker {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model_name: Option<String>,
@@ -1753,7 +1753,7 @@ impl LlmRanker {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum RankingConfig {
     RankService(RankService),
     LlmRanker(LlmRanker),
@@ -1761,7 +1761,7 @@ pub enum RankingConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct Ranking {
     #[serde(flatten)]
     pub ranking_config: RankingConfig,
@@ -1789,7 +1789,7 @@ impl Ranking {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum ApiSpecType {
     ApiSpecUnspecified,
     SimpleSearch,
@@ -1797,7 +1797,7 @@ pub enum ApiSpecType {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct SimpleSearchParams {}
 
 #[pymethods]
@@ -1810,7 +1810,7 @@ impl SimpleSearchParams {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ElasticSearchParams {
     pub index: String,
     pub search_template: String,
@@ -1841,7 +1841,7 @@ pub enum ExternalApiParams {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum AuthType {
     AuthTypeUnspecified,
     NoAuth,
@@ -1854,7 +1854,7 @@ pub enum AuthType {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum HttpElementLocation {
     HttpInUnspecified,
     HttpInQuery,
@@ -1866,7 +1866,7 @@ pub enum HttpElementLocation {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ApiKeyConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -1900,7 +1900,7 @@ impl ApiKeyConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct HttpBasicAuthConfig {
     pub credential_secret: String,
 }
@@ -1915,7 +1915,7 @@ impl HttpBasicAuthConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct GoogleServiceAccountConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_account: Option<String>,
@@ -1933,7 +1933,7 @@ impl GoogleServiceAccountConfig {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum OauthConfigValue {
     AccessToken(String),
     ServiceAccount(String),
@@ -1957,7 +1957,7 @@ impl OauthConfigValue {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct OauthConfig {
     #[serde(flatten)]
     pub oauth_config: OauthConfigValue,
@@ -1988,7 +1988,7 @@ pub enum OidcConfigValue {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct OidcConfig {
     #[serde(flatten)]
     pub oidc_config: OidcConfigValue,
@@ -2017,7 +2017,7 @@ impl OidcConfig {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum AuthConfigValue {
     ApiKeyConfig(ApiKeyConfig),
     HttpBasicAuthConfig(HttpBasicAuthConfig),
@@ -2076,7 +2076,7 @@ impl AuthConfigValue {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct AuthConfig {
     pub auth_type: AuthType,
     #[serde(flatten)]
@@ -2085,7 +2085,7 @@ pub struct AuthConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ExternalApi {
     pub api_spec: ApiSpecType,
     pub endpoint: String,
@@ -2122,7 +2122,7 @@ impl ExternalApi {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum RetrievalSource {
     VertexAiSearch(VertexAISearch),
     VertexRagStore(VertexRagStore),
@@ -2149,7 +2149,7 @@ impl RetrievalSource {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct Retrieval {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_attribution: Option<bool>,
@@ -2171,7 +2171,7 @@ impl Retrieval {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct Interval {
     #[pyo3(get)]
     pub start_time: String,
@@ -2181,7 +2181,7 @@ pub struct Interval {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct GoogleSearch {
     #[pyo3(get)]
     pub time_range_filter: Interval,
@@ -2189,7 +2189,7 @@ pub struct GoogleSearch {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum PhishBlockThreshold {
     PhishBlockThresholdUnspecified,
     BlockLowAndAbove,
@@ -2202,7 +2202,7 @@ pub enum PhishBlockThreshold {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct VertexGoogleSearch {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exclude_domains: Option<Vec<String>>,
@@ -2228,7 +2228,7 @@ impl VertexGoogleSearch {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct EnterpriseWebSearch {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exclude_domains: Option<Vec<String>>,
@@ -2254,7 +2254,7 @@ impl EnterpriseWebSearch {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ParallelAiSearch {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
@@ -2292,7 +2292,7 @@ impl ParallelAiSearch {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum GoogleSearchNum {
     GeminiSearch(GoogleSearch),
     VertexSearch(VertexGoogleSearch),
@@ -2316,7 +2316,7 @@ impl GoogleSearchNum {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum DynamicRetrievalMode {
     ModeUnspecified,
     ModeDynamic,
@@ -2324,7 +2324,7 @@ pub enum DynamicRetrievalMode {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct DynamicRetrievalConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<DynamicRetrievalMode>,
@@ -2346,7 +2346,7 @@ impl DynamicRetrievalConfig {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct GoogleSearchRetrieval {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dynamic_retrieval_config: Option<DynamicRetrievalConfig>,
@@ -2365,7 +2365,7 @@ impl GoogleSearchRetrieval {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct GoogleMaps {
     pub enable_widget: bool,
 }
@@ -2381,7 +2381,7 @@ impl GoogleMaps {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct CodeExecution {}
 
 #[pymethods]
@@ -2394,7 +2394,7 @@ impl CodeExecution {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum ComputerUseEnvironment {
     EnvironmentUnspecified,
     EnvironmentBrowser,
@@ -2402,7 +2402,7 @@ pub enum ComputerUseEnvironment {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ComputerUse {
     pub environment: ComputerUseEnvironment,
     pub excluded_predefined_functions: Vec<String>,
@@ -2424,7 +2424,7 @@ impl ComputerUse {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct UrlContext {}
 
 #[pymethods]
@@ -2437,7 +2437,7 @@ impl UrlContext {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct FileSearch {
     pub file_search_store_names: Vec<String>,
     pub metadata_filter: String,
@@ -2459,7 +2459,7 @@ impl FileSearch {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "camelCase", default)]
-#[pyclass(name = "GeminiTool")]
+#[pyclass(from_py_object, name = "GeminiTool")]
 #[pyo3(get_all)]
 pub struct Tool {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/potato_type/src/google/v1/generate/response.rs
+++ b/crates/potato_type/src/google/v1/generate/response.rs
@@ -13,7 +13,7 @@ use serde_json::Value;
 use std::fmt;
 use std::fmt::Display;
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum TrafficType {
@@ -22,7 +22,7 @@ pub enum TrafficType {
     ProvisionedThroughput,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -33,7 +33,7 @@ pub struct ModalityTokenCount {
     pub token_count: Option<i32>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -62,7 +62,7 @@ pub struct UsageMetadata {
     pub traffic_type: Option<TrafficType>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum BlockedReason {
@@ -76,7 +76,7 @@ pub enum BlockedReason {
     Jailbreak,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -89,7 +89,7 @@ pub struct PromptFeedback {
     pub block_reason_message: Option<String>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum UrlRetrievalStatus {
@@ -98,7 +98,7 @@ pub enum UrlRetrievalStatus {
     UrlRetrievalStatusError,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -111,7 +111,7 @@ pub struct UrlMetadata {
     pub url_retrieval_status: Option<UrlRetrievalStatus>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -121,7 +121,7 @@ pub struct UrlContextMetadata {
     pub url_metadata: Option<Vec<UrlMetadata>>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -132,7 +132,7 @@ pub struct SourceFlaggingUri {
     pub flag_content_uri: String,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -145,7 +145,7 @@ pub struct RetrievalMetadata {
     pub google_search_dynamic_retrieval_score: Option<f64>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -158,7 +158,7 @@ pub struct SearchEntryPoint {
     pub sdk_blob: Option<String>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -177,7 +177,7 @@ pub struct Segment {
     pub text: Option<String>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -196,7 +196,7 @@ pub struct GroundingSupport {
     pub segment: Option<Segment>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -212,7 +212,7 @@ pub struct Web {
     pub domain: Option<String>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -223,7 +223,7 @@ pub struct PageSpan {
     pub last_page: i32,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -233,7 +233,7 @@ pub struct RagChunk {
     pub page_span: Option<PageSpan>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -251,7 +251,7 @@ pub struct RetrievedContext {
     pub rag_chunk: Option<RagChunk>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -269,7 +269,7 @@ pub struct Maps {
     pub place_id: Option<String>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
@@ -279,7 +279,7 @@ pub enum GroundingChunkType {
     Maps(Maps),
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -288,7 +288,7 @@ pub struct GroundingChunk {
     pub chunk_type: GroundingChunkType,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -330,7 +330,7 @@ pub struct GroundingMetadata {
     pub image_search_queries: Option<Vec<String>>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum HarmProbability {
@@ -341,7 +341,7 @@ pub enum HarmProbability {
     High,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum HarmSeverity {
@@ -352,7 +352,7 @@ pub enum HarmSeverity {
     HarmSeverityHigh,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -370,7 +370,7 @@ pub struct SafetyRating {
     pub overwritten_threshold: Option<HarmBlockThreshold>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum FinishReason {
@@ -445,7 +445,7 @@ impl FinishReason {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -460,7 +460,7 @@ pub struct LogprobsCandidate {
     pub log_probability: Option<f64>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -468,7 +468,7 @@ pub struct TopCandidates {
     pub candidates: Option<Vec<LogprobsCandidate>>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -479,7 +479,7 @@ pub struct LogprobsResult {
     pub chosen_candidates: Option<Vec<LogprobsCandidate>>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -490,7 +490,7 @@ pub struct GoogleDate {
 }
 
 /// Source attributions for content.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -510,7 +510,7 @@ pub struct Citation {
 }
 
 /// A collection of source attributions for a piece of content.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -520,7 +520,7 @@ pub struct CitationMetadata {
 }
 
 /// A response candidate generated from the model.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -554,7 +554,7 @@ impl MessageResponseExt for Candidate {
 }
 
 /// Response message for GenerateContent.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[pyo3(get_all)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]

--- a/crates/potato_type/src/lib.rs
+++ b/crates/potato_type/src/lib.rs
@@ -20,7 +20,7 @@ pub mod tools;
 pub mod traits;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum Model {
     Undefined,
 }
@@ -59,7 +59,7 @@ impl Display for Common {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[pyclass(eq, eq_int)]
+#[pyclass(from_py_object, eq, eq_int)]
 pub enum Provider {
     OpenAI,
     Gemini,
@@ -127,7 +127,7 @@ impl Display for Provider {
     }
 }
 
-#[pyclass(eq, eq_int)]
+#[pyclass(from_py_object, eq, eq_int)]
 #[derive(Debug, PartialEq, Clone)]
 pub enum SaveName {
     Prompt,
@@ -236,7 +236,7 @@ pub trait StructuredOutput: for<'de> serde::Deserialize<'de> + JsonSchema {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum SettingsType {
     GoogleChat,
     OpenAIChat,

--- a/crates/potato_type/src/openai/v1/chat/request.rs
+++ b/crates/potato_type/src/openai/v1/chat/request.rs
@@ -29,7 +29,7 @@ pub const OPENAI_CONTENT_PART_INPUT_AUDIO: &str = "input_audio";
 pub const OPENAI_CONTENT_PART_FILE: &str = "file";
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct File {
     #[pyo3(get, set)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -60,7 +60,7 @@ impl File {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct FileContentPart {
     #[pyo3(get, set)]
     pub file: File,
@@ -89,7 +89,7 @@ impl FileContentPart {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct InputAudioData {
     #[pyo3(get, set)]
     pub data: String,
@@ -106,7 +106,7 @@ impl InputAudioData {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct InputAudioContentPart {
     #[pyo3(get, set)]
     pub input_audio: InputAudioData,
@@ -127,7 +127,7 @@ impl InputAudioContentPart {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ImageUrl {
     #[pyo3(get, set)]
     pub url: String,
@@ -146,7 +146,7 @@ impl ImageUrl {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ImageContentPart {
     #[pyo3(get, set)]
     pub image_url: ImageUrl,
@@ -168,7 +168,7 @@ impl ImageContentPart {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct TextContentPart {
     #[pyo3(get, set)]
     pub text: String,
@@ -240,7 +240,7 @@ fn extract_content_from_py_object(content: &Bound<'_, PyAny>) -> PyResult<Vec<Co
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ChatMessage {
     #[pyo3(get, set)]
     pub role: String,

--- a/crates/potato_type/src/openai/v1/chat/response.rs
+++ b/crates/potato_type/src/openai/v1/chat/response.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct Function {
     #[pyo3(get)]
     pub arguments: String,
@@ -26,7 +26,7 @@ pub struct Function {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ToolCall {
     #[pyo3(get)]
     pub id: String,
@@ -39,7 +39,7 @@ pub struct ToolCall {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct UrlCitation {
     #[pyo3(get)]
     pub end_index: u64,
@@ -53,7 +53,7 @@ pub struct UrlCitation {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct Annotations {
     #[pyo3(get)]
     pub r#type: String,
@@ -63,7 +63,7 @@ pub struct Annotations {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct Audio {
     #[pyo3(get)]
     pub data: String,
@@ -77,7 +77,7 @@ pub struct Audio {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct ChatCompletionMessage {
     #[pyo3(get)]
     pub content: Option<String>,
@@ -97,7 +97,7 @@ pub struct ChatCompletionMessage {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct TopLogProbs {
     #[pyo3(get)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -110,7 +110,7 @@ pub struct TopLogProbs {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct LogContent {
     #[pyo3(get)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -126,7 +126,7 @@ pub struct LogContent {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct LogProbs {
     #[pyo3(get)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -138,7 +138,7 @@ pub struct LogProbs {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct Choice {
     #[pyo3(get)]
     pub message: ChatCompletionMessage,
@@ -162,7 +162,7 @@ impl MessageResponseExt for Choice {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(default)]
 pub struct CompletionTokenDetails {
@@ -176,7 +176,7 @@ pub struct CompletionTokenDetails {
     pub rejected_prediction_tokens: u64,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(default)]
 pub struct PromptTokenDetails {
@@ -186,7 +186,7 @@ pub struct PromptTokenDetails {
     pub cached_tokens: u64,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(default)]
 pub struct Usage {
@@ -205,7 +205,7 @@ pub struct Usage {
     pub finish_reason: Option<String>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
 #[serde(default)]
 pub struct OpenAIChatResponse {

--- a/crates/potato_type/src/openai/v1/chat/settings.rs
+++ b/crates/potato_type/src/openai/v1/chat/settings.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct AudioParam {
     #[pyo3(get, set)]
     pub format: String,
@@ -35,7 +35,7 @@ impl AudioParam {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct PredictionContentPart {
     #[pyo3(get, set)]
     #[serde(rename = "type")]
@@ -63,7 +63,7 @@ impl PredictionContentPart {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum Content {
     Text(String),
     Array(Vec<PredictionContentPart>),
@@ -88,7 +88,7 @@ impl Content {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct Prediction {
     #[pyo3(get, set)]
     pub r#type: String,
@@ -105,7 +105,7 @@ impl Prediction {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct StreamOptions {
     #[pyo3(get, set)]
     pub include_obfuscation: Option<bool>,
@@ -124,7 +124,7 @@ impl StreamOptions {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ToolChoiceMode {
@@ -142,7 +142,7 @@ impl ToolChoiceMode {
 }
 
 /// Function specification for function tool choice
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct FunctionChoice {
     #[pyo3(get, set)]
@@ -163,7 +163,7 @@ impl FunctionChoice {
 }
 
 /// Function tool choice specification
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct FunctionToolChoice {
     #[pyo3(get)]
@@ -189,7 +189,7 @@ impl FunctionToolChoice {
 }
 
 /// Custom tool specification
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct CustomChoice {
     #[pyo3(get, set)]
@@ -210,7 +210,7 @@ impl CustomChoice {
 }
 
 /// Custom tool choice specification
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct CustomToolChoice {
     #[pyo3(get)]
@@ -235,7 +235,7 @@ impl CustomToolChoice {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ToolDefinition {
     #[pyo3(get)]
@@ -261,7 +261,7 @@ impl ToolDefinition {
 }
 
 /// Mode for allowed tools constraint
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum AllowedToolsMode {
@@ -278,7 +278,7 @@ impl AllowedToolsMode {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct InnerAllowedTools {
     #[pyo3(get)]
@@ -287,7 +287,7 @@ pub struct InnerAllowedTools {
     pub tools: Vec<ToolDefinition>,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct AllowedTools {
     #[pyo3(get)]
@@ -325,7 +325,7 @@ impl AllowedTools {
 }
 
 /// Tool choice configuration - can be a mode string or specific tool object
-#[pyclass(name = "OpenAIToolChoice")]
+#[pyclass(from_py_object, name = "OpenAIToolChoice")]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum ToolChoice {
@@ -380,7 +380,7 @@ impl Default for ToolChoice {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct FunctionDefinition {
     #[pyo3(get, set)]
@@ -437,7 +437,7 @@ impl FunctionDefinition {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct FunctionTool {
     #[pyo3(get, set)]
@@ -456,7 +456,7 @@ impl FunctionTool {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct TextFormat {
     #[pyo3(get, set)]
@@ -472,7 +472,7 @@ impl TextFormat {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Grammar {
     /// The grammar definition
@@ -497,7 +497,7 @@ impl Grammar {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct GrammarFormat {
     #[pyo3(get, set)]
@@ -515,7 +515,7 @@ impl GrammarFormat {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum CustomToolFormat {
@@ -540,7 +540,7 @@ impl CustomToolFormat {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CustomDefinition {
     #[pyo3(get, set)]
@@ -572,7 +572,7 @@ impl CustomDefinition {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CustomTool {
     #[pyo3(get, set)]
@@ -591,7 +591,7 @@ impl CustomTool {
     }
 }
 
-#[pyclass(name = "OpenAITool")]
+#[pyclass(from_py_object, name = "OpenAITool")]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum Tool {
@@ -617,7 +617,7 @@ impl Tool {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct OpenAIChatSettings {
     #[pyo3(get, set)]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/potato_type/src/openai/v1/embedding/mod.rs
+++ b/crates/potato_type/src/openai/v1/embedding/mod.rs
@@ -3,7 +3,7 @@ use pyo3::{prelude::*, IntoPyObjectExt};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct OpenAIEmbeddingConfig {
     #[pyo3(get)]
     pub model: String,
@@ -41,7 +41,7 @@ impl OpenAIEmbeddingConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct EmbeddingObject {
     #[pyo3(get)]
     pub object: String,
@@ -59,7 +59,7 @@ impl EmbeddingObject {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct UsageObject {
     #[pyo3(get)]
     pub prompt_tokens: u32,
@@ -68,7 +68,7 @@ pub struct UsageObject {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct OpenAIEmbeddingResponse {
     #[pyo3(get)]
     pub object: String,

--- a/crates/potato_type/src/prompt/interface.rs
+++ b/crates/potato_type/src/prompt/interface.rs
@@ -195,7 +195,7 @@ pub fn extract_system_instructions(
     Ok(system_instructions)
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct Prompt {
     pub request: ProviderRequest,

--- a/crates/potato_type/src/prompt/settings.rs
+++ b/crates/potato_type/src/prompt/settings.rs
@@ -10,7 +10,7 @@ use pyo3::IntoPyObjectExt;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)]

--- a/crates/potato_type/src/prompt/types.rs
+++ b/crates/potato_type/src/prompt/types.rs
@@ -20,7 +20,7 @@ use serde_json::Value;
 use std::fmt::Display;
 use tracing::error;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub enum Role {
     User,
     Assistant,
@@ -211,7 +211,7 @@ pub fn parse_response_to_json<'py>(
     Ok((ResponseType::Null, None))
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)] // ensure strict validation
 pub struct Score {
@@ -247,7 +247,7 @@ impl Score {
 
 impl StructuredOutput for Score {}
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub enum ResponseType {
     Score,
@@ -528,7 +528,7 @@ pub enum ResponseContent {
     PredictResponse(PredictResponse),
 }
 
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 pub struct OpenAIMessageList {
     pub messages: Vec<OpenAIChatMessage>,
 }
@@ -569,7 +569,7 @@ impl OpenAIMessageList {
     }
 }
 
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 pub struct OpenAIMessageIterator {
     inner: std::vec::IntoIter<OpenAIChatMessage>,
 }
@@ -585,7 +585,7 @@ impl OpenAIMessageIterator {
     }
 }
 
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 pub struct AnthropicMessageList {
     pub messages: Vec<AnthropicMessage>,
 }
@@ -626,7 +626,7 @@ impl AnthropicMessageList {
     }
 }
 
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 pub struct AnthropicMessageIterator {
     inner: std::vec::IntoIter<AnthropicMessage>,
 }
@@ -642,7 +642,7 @@ impl AnthropicMessageIterator {
     }
 }
 
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 pub struct GeminiContentList {
     pub messages: Vec<GeminiContent>,
 }
@@ -683,7 +683,7 @@ impl GeminiContentList {
     }
 }
 
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 pub struct GeminiContentIterator {
     inner: std::vec::IntoIter<GeminiContent>,
 }

--- a/crates/potato_util/src/utils.rs
+++ b/crates/potato_util/src/utils.rs
@@ -191,7 +191,7 @@ pub fn extract_string_value(py_value: &Bound<'_, PyAny>) -> Result<String, UtilE
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Clone)]
 pub struct TokenLogProbs {
     #[pyo3(get)]
@@ -201,7 +201,7 @@ pub struct TokenLogProbs {
     pub logprob: f64,
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Serialize, Clone)]
 pub struct ResponseLogProbs {
     #[pyo3(get)]

--- a/crates/potato_workflow/src/workflow/events.rs
+++ b/crates/potato_workflow/src/workflow/events.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::RwLock;
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TaskEvent {
     #[pyo3(get)]
@@ -37,7 +37,7 @@ impl TaskEvent {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct EventDetails {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/potato_workflow/src/workflow/flow.rs
+++ b/crates/potato_workflow/src/workflow/flow.rs
@@ -35,7 +35,7 @@ use pyo3::types::PyDict;
 pub type Context = (HashMap<String, Vec<MessageNum>>, Value, Option<Arc<Value>>);
 
 #[derive(Debug)]
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 pub struct WorkflowResult {
     #[pyo3(get)]
     pub tasks: HashMap<String, Py<WorkflowTask>>,
@@ -882,7 +882,7 @@ impl<'de> Deserialize<'de> for Workflow {
     }
 }
 
-#[pyclass(name = "Workflow")]
+#[pyclass(skip_from_py_object, name = "Workflow")]
 #[derive(Debug, Clone)]
 pub struct PyWorkflow {
     workflow: Workflow,

--- a/crates/potato_workflow/src/workflow/tasklist.rs
+++ b/crates/potato_workflow/src/workflow/tasklist.rs
@@ -16,7 +16,7 @@ use tracing::instrument;
 use tracing::{debug, warn};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct TaskList {
     pub tasks: HashMap<String, Arc<RwLock<Task>>>,
     pub execution_order: Vec<String>,

--- a/py-potato/CLAUDE.md
+++ b/py-potato/CLAUDE.md
@@ -44,7 +44,7 @@ uv run maturin develop
 Nine crates under `crates/`:
 
 - **potato_head** — Public API aggregator; re-exports from other crates
-- **potato_type** — Type definitions for all providers (OpenAI, Gemini, Anthropic). PyO3 `#[pyclass]` annotations live here.
+- **potato_type** — Type definitions for all providers (OpenAI, Gemini, Anthropic). PyO3 `#[pyclass(from_py_object)]` annotations live here.
 - **potato_provider** — LLM provider HTTP clients
 - **potato_agent** — Agent execution engine
 - **potato_workflow** — Workflow/task orchestration
@@ -63,7 +63,7 @@ Thin wrappers and re-exports from the compiled `_potato_head` native module. Pro
 
 ### Adding a New Type (end-to-end)
 
-1. Define the Rust struct with `#[pyclass]` in the appropriate `potato_type` submodule
+1. Define the Rust struct with `#[pyclass(from_py_object)]` in the appropriate `potato_type` submodule
 2. Register it in the PyO3 module (`py-potato/src/<provider>.rs`)
 3. Export from the Python `__init__.py` for that provider
 4. Regenerate stubs: `uv run python scripts/create_stubs.py`

--- a/py-potato/pyproject.toml
+++ b/py-potato/pyproject.toml
@@ -6,7 +6,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-version = "0.20.0"
+version = "0.21.0"
 description = ""
 authors = [
     {name = "Thorrester", email = "<support@demmlai.com>"},

--- a/py-potato/uv.lock
+++ b/py-potato/uv.lock
@@ -3360,7 +3360,7 @@ wheels = [
 
 [[package]]
 name = "potato-head"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Pull Request

### Short Summary

Bumps pyo3 from `0.27.2` to `0.28.*` and adds `from_py_object` to every `#[pyclass]` annotation across the codebase. PyO3 0.28 requires explicit opt-in for `FromPyObject` derivation on `#[pyclass]` types — previously it was implicit.

### Context

PyO3 0.28 changed how `#[pyclass]` types participate in Python-to-Rust extraction. Types that need to be accepted as function arguments or extracted from `PyAny` now require `#[pyclass(from_py_object)]` to generate the `FromPyObject` impl. Without it, extraction silently fails to compile or panics at runtime depending on call site.

Every `#[pyclass]` in `potato_type` that was used at an extraction boundary needed the annotation. That covers all request/response structs for OpenAI, Anthropic, and Google providers, plus the top-level enums (`Model`, `Provider`, `SaveName`, `SettingsType`).

| File | Change |
|---|---|
| `Cargo.toml` | `pyo3 = "0.27.2"` → `"0.28.*"` |
| `crates/potato_type/src/lib.rs` | `from_py_object` on `Model`, `Provider`, `SaveName`, `SettingsType` |
| `crates/potato_type/src/openai/v1/chat/request.rs` | `from_py_object` on 8 structs |
| `crates/potato_type/src/openai/v1/chat/response.rs` | `from_py_object` on 14 structs |
| `crates/potato_type/src/openai/v1/chat/settings.rs` | `from_py_object` on 9 structs/enums |
| `crates/potato_type/src/anthropic/v1/request.rs` | `from_py_object` on 10+ structs |
| `crates/potato_type/src/anthropic/v1/response.rs` | `from_py_object` on response types |
| `crates/potato_type/src/google/v1/generate/request.rs` | `from_py_object` on request types |
| `crates/potato_type/src/google/v1/generate/response.rs` | `from_py_object` on response types |
| `Cargo.lock` | Full lockfile refresh from version bump |

The `Cargo.lock` diff is large (~650 lines) purely from transitive dependency churn on the pyo3 upgrade — no other dep versions changed intentionally.

### Is this a Breaking Change?

No. All public Rust and Python interfaces are unchanged. The `from_py_object` annotation restores behavior that was implicit in 0.27 — callers see identical extraction semantics.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/demml/potatohead/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
