### PR TITLE
add response text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "baked-potato"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1637,7 +1637,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potato-agent"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "potato-head"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "baked-potato",
  "potato-agent",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "potato-provider"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "base64",
  "gcloud-auth",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "potato-spec"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "potato-agent",
  "potato-type",
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "potato-state"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "thiserror 2.0.18",
  "tokio",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "potato-type"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-trait",
  "potato-util",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "potato-util"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "colored_json",
  "pyo3",
@@ -1753,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "potato-workflow"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "chrono",
  "potato-agent",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "potatohead-macro"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "py-potatohead"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "potato-head",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,23 +9,23 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.23.0"
+version = "0.24.0"
 authors = ["demml <support@demmlai.com>"]
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/demml/potatohead"
 
 [workspace.dependencies]
-baked-potato = { path = "crates/baked_potato", version = "0.23.0" }
-potato-agent = { path = "crates/potato_agent", version = "0.23.0" }
-potato-provider = { path = "crates/potato_provider", version = "0.23.0" }
-potatohead-macro = { path = "crates/potato_macro", version = "0.23.0" }
-potato-type = { path = "crates/potato_type", version = "0.23.0" }
-potato-workflow = { path = "crates/potato_workflow", version = "0.23.0" }
-potato-util = { path = "crates/potato_util", version = "0.23.0" }
-potato-head = { path = "crates/potato_head", version = "0.23.0" }
-potato-state = { path = "crates/potato_state", version = "0.23.0" }
-potato-spec = { path = "crates/potato_spec", version = "0.23.0" }
+baked-potato = { path = "crates/baked_potato", version = "0.24.0" }
+potato-agent = { path = "crates/potato_agent", version = "0.24.0" }
+potato-provider = { path = "crates/potato_provider", version = "0.24.0" }
+potatohead-macro = { path = "crates/potato_macro", version = "0.24.0" }
+potato-type = { path = "crates/potato_type", version = "0.24.0" }
+potato-workflow = { path = "crates/potato_workflow", version = "0.24.0" }
+potato-util = { path = "crates/potato_util", version = "0.24.0" }
+potato-head = { path = "crates/potato_head", version = "0.24.0" }
+potato-state = { path = "crates/potato_state", version = "0.24.0" }
+potato-spec = { path = "crates/potato_spec", version = "0.24.0" }
 
 anyhow = "1.0.93"
 async-trait = "0.*"

--- a/crates/baked_potato/tests/workflow/test_workflow.rs
+++ b/crates/baked_potato/tests/workflow/test_workflow.rs
@@ -455,7 +455,10 @@ fn test_vendor_switching() {
     assert!(workflow_result.is_complete());
 
     // Get task references
-    let openai_task = workflow_result.task_list.get_task("openai_task").unwrap();
+    let openai_task = workflow_result
+        .task_list
+        .get_task("openai_task")
+        .unwrap();
     let anthropic_task = workflow_result
         .task_list
         .get_task("anthropic_task")
@@ -567,6 +570,43 @@ fn test_vendor_switching() {
             }
         }
     }
+
+    mock.stop_server().unwrap();
+}
+
+#[test]
+fn test_workflow_execute_task_plaintext_fallback() {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let mut mock = LLMTestServer::new();
+    mock.start_server().unwrap();
+
+    let prompt = create_openai_prompt(None);
+    let mut workflow = Workflow::new("Plaintext Workflow");
+
+    let agent = runtime
+        .block_on(async { Agent::new(Provider::OpenAI, None).await })
+        .unwrap();
+    workflow.add_agent(&agent);
+    workflow
+        .add_task(Task::new(&agent.id, prompt, "task1", None, None).unwrap())
+        .unwrap();
+
+    let result = runtime.block_on(async {
+        workflow
+            .execute_task("task1", &serde_json::Value::Null)
+            .await
+            .unwrap()
+    });
+
+    assert!(
+        result.is_string(),
+        "plain-text task should return Value::String, got: {:?}",
+        result
+    );
+    assert!(
+        !result.as_str().unwrap_or("").is_empty(),
+        "plain-text task response should be non-empty"
+    );
 
     mock.stop_server().unwrap();
 }

--- a/crates/potato_workflow/src/workflow/flow.rs
+++ b/crates/potato_workflow/src/workflow/flow.rs
@@ -306,7 +306,11 @@ impl Workflow {
                         continue;
                     }
 
-                    return Ok(response.response_value().unwrap_or(Value::Null));
+                    let value = match response.response_value() {
+                        Some(v) => v,
+                        None => Value::String(response.response_text()),
+                    };
+                    return Ok(value);
                 }
                 Err(e) => {
                     let task_id = { task.read().unwrap().id.clone() };

--- a/py-potato/pyproject.toml
+++ b/py-potato/pyproject.toml
@@ -6,7 +6,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-version = "0.23.0"
+version = "0.24.0"
 description = ""
 authors = [
     {name = "Thorrester", email = "<support@demmlai.com>"},

--- a/py-potato/tests/test_workflow.py
+++ b/py-potato/tests/test_workflow.py
@@ -469,3 +469,28 @@ def test_potato_head_workflow_structured_output_execute_task():
         )
         result = workflow.execute_task("task1")
         StructuredTaskOutput(**result)
+
+
+def test_potato_head_workflow_plaintext_execute_task():
+    with LLMTestServer():
+        prompt = Prompt(
+            messages="Hello, how are you?",
+            system_instructions="You are a helpful assistant.",
+            model="gpt-4o",
+            provider="openai",
+        )
+
+        agent = Agent(Provider.OpenAI)
+
+        workflow = Workflow(name="test_plaintext_workflow")
+        workflow.add_agent(agent)
+        workflow.add_task(
+            Task(
+                prompt=prompt,
+                agent_id=agent.id,
+                id="task1",
+            ),
+        )
+        result = workflow.execute_task("task1")
+        assert isinstance(result, str), f"Expected str, got {type(result)}"
+        assert len(result) > 0, "Plain-text response should be non-empty"

--- a/py-potato/uv.lock
+++ b/py-potato/uv.lock
@@ -3360,7 +3360,7 @@ wheels = [
 
 [[package]]
 name = "potato-head"
-version = "0.23.0"
+version = "0.24.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Pull Request

### Short Summary

Fixes `execute_task` silently returning `null` when a workflow task receives a plain-text LLM response. When `response_value()` returns `None` (no structured JSON), the result now falls back to `Value::String(response.response_text())` instead of `Value::Null`.

### Context

`Workflow::execute_task` in `flow.rs` extracts the task result via `response.response_value()`, which returns `Some(Value)` only for structured/JSON responses. Plain-text responses — valid and common — returned `None`, and the previous code silently substituted `Value::Null`. That made it impossible for callers to distinguish "no output" from "plain-text output they can't use."

**Before:**
```rust
return Ok(response.response_value().unwrap_or(Value::Null));
```

**After:**
```rust
let value = match response.response_value() {
    Some(v) => v,
    None => Value::String(response.response_text()),
};
return Ok(value);
```

Coverage for this path was missing in both Rust and Python tests. Both are now added.

| File | Change |
|---|---|
| `crates/potato_workflow/src/workflow/flow.rs` | Plain-text fallback in `execute_task` return path |
| `crates/baked_potato/tests/workflow/test_workflow.rs` | `test_workflow_execute_task_plaintext_fallback` — asserts `Value::String` returned |
| `py-potato/tests/test_workflow.py` | `test_potato_head_workflow_plaintext_execute_task` — asserts `isinstance(result, str)` and non-empty |

### Is this a Breaking Change?

No. Tasks that return structured JSON continue to use `response_value()` unchanged. The only behavior change is for plain-text responses, which previously returned `null` (effectively unusable) and now return the response text as a JSON string.
