### PR TITLE
adding default provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ make test.integration.vertex
 | `GEMINI_API_KEY` | Google Gemini |
 | `ANTHROPIC_API_KEY` | Anthropic |
 | `GOOGLE_ACCOUNT_JSON_BASE64` | Vertex AI (base64 service account JSON) |
+| `POTATO_HEAD_DEFAULT_PROVIDER` | Default provider when YAML/JSON/`Prompt(...)`/`Agent(...)` omits `provider`. Values: `openai`, `gemini`, `google`, `vertex`, `anthropic`, `google_adk`. |
 
 Unit tests and mock-based tests require no credentials.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "baked-potato"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1637,7 +1637,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potato-agent"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "potato-head"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "baked-potato",
  "potato-agent",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "potato-provider"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "base64",
  "gcloud-auth",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "potato-spec"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "potato-agent",
  "potato-type",
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "potato-state"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "thiserror 2.0.18",
  "tokio",
@@ -1720,7 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "potato-type"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "potato-util"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "colored_json",
  "pyo3",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "potato-workflow"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "chrono",
  "potato-agent",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "potatohead-macro"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "py-potatohead"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "potato-head",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,23 +9,23 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.25.0"
+version = "0.26.0"
 authors = ["demml <support@demmlai.com>"]
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/demml/potatohead"
 
 [workspace.dependencies]
-baked-potato = { path = "crates/baked_potato", version = "0.25.0" }
-potato-agent = { path = "crates/potato_agent", version = "0.25.0" }
-potato-provider = { path = "crates/potato_provider", version = "0.25.0" }
-potatohead-macro = { path = "crates/potato_macro", version = "0.25.0" }
-potato-type = { path = "crates/potato_type", version = "0.25.0" }
-potato-workflow = { path = "crates/potato_workflow", version = "0.25.0" }
-potato-util = { path = "crates/potato_util", version = "0.25.0" }
-potato-head = { path = "crates/potato_head", version = "0.25.0" }
-potato-state = { path = "crates/potato_state", version = "0.25.0" }
-potato-spec = { path = "crates/potato_spec", version = "0.25.0" }
+baked-potato = { path = "crates/baked_potato", version = "0.26.0" }
+potato-agent = { path = "crates/potato_agent", version = "0.26.0" }
+potato-provider = { path = "crates/potato_provider", version = "0.26.0" }
+potatohead-macro = { path = "crates/potato_macro", version = "0.26.0" }
+potato-type = { path = "crates/potato_type", version = "0.26.0" }
+potato-workflow = { path = "crates/potato_workflow", version = "0.26.0" }
+potato-util = { path = "crates/potato_util", version = "0.26.0" }
+potato-head = { path = "crates/potato_head", version = "0.26.0" }
+potato-state = { path = "crates/potato_state", version = "0.26.0" }
+potato-spec = { path = "crates/potato_spec", version = "0.26.0" }
 
 anyhow = "1.0.93"
 async-trait = "0.*"

--- a/crates/potato_agent/src/agents/agent.rs
+++ b/crates/potato_agent/src/agents/agent.rs
@@ -931,18 +931,17 @@ pub struct PyAgent {
 #[pymethods]
 impl PyAgent {
     #[new]
-    #[pyo3(signature = (provider, system_instruction = None))]
+    #[pyo3(signature = (provider=None, system_instruction = None))]
     /// Creates a new Agent instance.
     ///
     /// # Arguments:
-    /// * `provider` - A Python object representing the provider, expected to be an a variant of Provider or a string
-    /// that can be mapped to a provider variant
+    /// * `provider` - Optional. Defaults to env var POTATO_HEAD_DEFAULT_PROVIDER if unset.
     ///
     pub fn new(
-        provider: &Bound<'_, PyAny>,
+        provider: Option<&Bound<'_, PyAny>>,
         system_instruction: Option<&Bound<'_, PyAny>>,
     ) -> Result<Self, AgentError> {
-        let provider = Provider::extract_provider(provider)?;
+        let provider = Provider::resolve_from_py(provider)?;
         let system_instructions = extract_system_instructions(system_instruction, &provider)?;
         let agent = block_on(async { Agent::new(provider, system_instructions).await })?;
 

--- a/crates/potato_spec/src/loader.rs
+++ b/crates/potato_spec/src/loader.rs
@@ -150,11 +150,12 @@ impl SpecLoader {
     }
 
     async fn build_agent(&self, spec: &AgentSpec) -> Result<Arc<Agent>, SpecError> {
-        let provider =
-            Provider::from_string(&spec.provider).map_err(|_| SpecError::InvalidProvider {
-                value: spec.provider.clone(),
-                reason: "unknown provider name".into(),
-            })?;
+        let provider = Provider::resolve(spec.provider.as_deref()).map_err(|e| {
+            SpecError::InvalidProvider {
+                value: spec.provider.clone().unwrap_or_default(),
+                reason: e.to_string(),
+            }
+        })?;
 
         let mut builder = AgentBuilder::new().provider(provider);
 
@@ -419,7 +420,24 @@ impl LoadedSpec {
 mod tests {
     use super::*;
     use std::fs;
+    use std::sync::Mutex;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env_var<F: FnOnce()>(value: Option<&str>, f: F) {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var(Provider::DEFAULT_ENV_VAR).ok();
+        match value {
+            Some(v) => std::env::set_var(Provider::DEFAULT_ENV_VAR, v),
+            None => std::env::remove_var(Provider::DEFAULT_ENV_VAR),
+        }
+        f();
+        match prev {
+            Some(v) => std::env::set_var(Provider::DEFAULT_ENV_VAR, v),
+            None => std::env::remove_var(Provider::DEFAULT_ENV_VAR),
+        }
+    }
 
     fn create_temp_spec_dir() -> PathBuf {
         let nanos = SystemTime::now()
@@ -507,6 +525,61 @@ workflows:
         assert!(loaded.workflow("dag").is_some());
 
         fs::remove_dir_all(temp_dir).unwrap();
+    }
+
+    #[test]
+    fn agent_spec_without_provider_uses_env_default() {
+        with_env_var(Some("openai"), || {
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            let spec = AgentSpec {
+                id: "worker".to_string(),
+                provider: None,
+                model: Some("gpt-4o".to_string()),
+                system_prompt: None,
+                max_iterations: Some(1),
+                memory: None,
+                criteria: Vec::new(),
+                callbacks: Vec::new(),
+                tools: Vec::new(),
+            };
+            let loader = SpecLoader::new();
+
+            let agent = runtime
+                .block_on(async { loader.build_agent(&spec).await })
+                .unwrap();
+
+            assert_eq!(agent.client_provider(), &Provider::OpenAI);
+        });
+    }
+
+    #[test]
+    fn agent_spec_without_provider_no_env_errors() {
+        with_env_var(None, || {
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            let spec = AgentSpec {
+                id: "worker".to_string(),
+                provider: None,
+                model: Some("gpt-4o".to_string()),
+                system_prompt: None,
+                max_iterations: Some(1),
+                memory: None,
+                criteria: Vec::new(),
+                callbacks: Vec::new(),
+                tools: Vec::new(),
+            };
+            let loader = SpecLoader::new();
+
+            let err = runtime
+                .block_on(async { loader.build_agent(&spec).await })
+                .unwrap_err();
+
+            match err {
+                SpecError::InvalidProvider { reason, .. } => {
+                    assert!(reason.contains(Provider::DEFAULT_ENV_VAR));
+                }
+                other => panic!("expected InvalidProvider, got {:?}", other),
+            }
+        });
     }
 
     #[test]

--- a/crates/potato_spec/src/spec.rs
+++ b/crates/potato_spec/src/spec.rs
@@ -46,7 +46,8 @@ pub struct PotatoSpec {
 #[derive(Debug, Deserialize, Clone)]
 pub struct AgentSpec {
     pub id: String,
-    pub provider: String,
+    #[serde(default)]
+    pub provider: Option<String>,
     pub model: Option<String>,
     pub system_prompt: Option<String>,
     pub max_iterations: Option<u32>,

--- a/crates/potato_spec/tests/load_spec.rs
+++ b/crates/potato_spec/tests/load_spec.rs
@@ -10,7 +10,7 @@ fn test_parse_simple_yaml() {
     let spec: PotatoSpec = serde_yaml::from_str(SIMPLE_YAML).unwrap();
     assert_eq!(spec.agents.len(), 1);
     assert_eq!(spec.agents[0].id, "summarizer");
-    assert_eq!(spec.agents[0].provider, "anthropic");
+    assert_eq!(spec.agents[0].provider.as_deref(), Some("anthropic"));
     assert_eq!(spec.agents[0].model.as_deref(), Some("claude-haiku-4-5"));
     assert_eq!(spec.agents[0].max_iterations, Some(3));
     assert_eq!(spec.workflows.len(), 1);

--- a/crates/potato_type/src/error.rs
+++ b/crates/potato_type/src/error.rs
@@ -13,6 +13,9 @@ pub enum TypeError {
     #[error("Unknown provider: {0}")]
     UnknownProviderError(String),
 
+    #[error("No provider specified. Pass `provider=` explicitly or set the {0} env var.")]
+    MissingProviderError(&'static str),
+
     #[error("Unknown model: {0}")]
     UnknownModelError(String),
 

--- a/crates/potato_type/src/lib.rs
+++ b/crates/potato_type/src/lib.rs
@@ -85,6 +85,47 @@ impl Provider {
         }
     }
 
+    pub const DEFAULT_ENV_VAR: &'static str = "POTATO_HEAD_DEFAULT_PROVIDER";
+
+    /// Reads `POTATO_HEAD_DEFAULT_PROVIDER` from the environment.
+    ///
+    /// - Unset, empty, or whitespace-only -> `Ok(None)`
+    /// - Set and parseable -> `Ok(Some(provider))`
+    /// - Set but unparseable -> `Err(TypeError::UnknownProviderError(...))`
+    pub fn from_env_default() -> Result<Option<Provider>, TypeError> {
+        match std::env::var(Self::DEFAULT_ENV_VAR) {
+            Ok(s) => {
+                let trimmed = s.trim();
+                if trimmed.is_empty() {
+                    Ok(None)
+                } else {
+                    Provider::from_string(trimmed).map(Some)
+                }
+            }
+            Err(_) => Ok(None),
+        }
+    }
+
+    /// Resolve a provider from an optional explicit string, falling back to the env var,
+    /// then erroring with `MissingProviderError` if neither is available.
+    pub fn resolve(provided: Option<&str>) -> Result<Provider, TypeError> {
+        if let Some(s) = provided.map(str::trim).filter(|s| !s.is_empty()) {
+            return Provider::from_string(s);
+        }
+
+        Self::from_env_default()?.ok_or(TypeError::MissingProviderError(Self::DEFAULT_ENV_VAR))
+    }
+
+    /// PyO3-friendly resolution: accepts an optional `Bound<'_, PyAny>` (Provider enum or string).
+    /// `None` or `py.None()` triggers env-var fallback.
+    pub fn resolve_from_py(provider: Option<&Bound<'_, PyAny>>) -> Result<Provider, TypeError> {
+        match provider {
+            Some(p) if !p.is_none() => Self::extract_provider(p),
+            _ => Self::from_env_default()?
+                .ok_or(TypeError::MissingProviderError(Self::DEFAULT_ENV_VAR)),
+        }
+    }
+
     /// Extract provider from a PyAny object
     ///
     /// # Arguments
@@ -248,6 +289,23 @@ pub enum SettingsType {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env_var<F: FnOnce()>(value: Option<&str>, f: F) {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var(Provider::DEFAULT_ENV_VAR).ok();
+        match value {
+            Some(v) => std::env::set_var(Provider::DEFAULT_ENV_VAR, v),
+            None => std::env::remove_var(Provider::DEFAULT_ENV_VAR),
+        }
+        f();
+        match prev {
+            Some(v) => std::env::set_var(Provider::DEFAULT_ENV_VAR, v),
+            None => std::env::remove_var(Provider::DEFAULT_ENV_VAR),
+        }
+    }
 
     #[test]
     fn test_provider_google_adk_round_trip() {
@@ -276,5 +334,82 @@ mod tests {
     #[test]
     fn test_provider_unknown_string_errors() {
         assert!(Provider::from_string("not_a_provider").is_err());
+    }
+
+    #[test]
+    fn resolve_explicit_wins_over_env() {
+        with_env_var(Some("anthropic"), || {
+            let p = Provider::resolve(Some("openai")).unwrap();
+            assert_eq!(p, Provider::OpenAI);
+        });
+    }
+
+    #[test]
+    fn resolve_uses_env_when_explicit_missing() {
+        with_env_var(Some("openai"), || {
+            let p = Provider::resolve(None).unwrap();
+            assert_eq!(p, Provider::OpenAI);
+        });
+    }
+
+    #[test]
+    fn resolve_uses_env_when_explicit_empty_string() {
+        with_env_var(Some("openai"), || {
+            let p = Provider::resolve(Some("   ")).unwrap();
+            assert_eq!(p, Provider::OpenAI);
+        });
+    }
+
+    #[test]
+    fn resolve_empty_env_treated_as_unset() {
+        with_env_var(Some("   "), || {
+            let err = Provider::resolve(None).unwrap_err();
+            assert!(matches!(err, TypeError::MissingProviderError(_)));
+        });
+    }
+
+    #[test]
+    fn resolve_invalid_env_is_hard_error() {
+        with_env_var(Some("not_a_provider"), || {
+            let err = Provider::resolve(None).unwrap_err();
+            assert!(matches!(err, TypeError::UnknownProviderError(_)));
+        });
+    }
+
+    #[test]
+    fn resolve_no_explicit_no_env_returns_missing() {
+        with_env_var(None, || {
+            let err = Provider::resolve(None).unwrap_err();
+            match err {
+                TypeError::MissingProviderError(name) => {
+                    assert_eq!(name, "POTATO_HEAD_DEFAULT_PROVIDER");
+                }
+                other => panic!("expected MissingProviderError, got {:?}", other),
+            }
+        });
+    }
+
+    #[test]
+    fn from_env_default_unset_returns_none() {
+        with_env_var(None, || {
+            assert!(Provider::from_env_default().unwrap().is_none());
+        });
+    }
+
+    #[test]
+    fn from_env_default_set_and_parseable() {
+        with_env_var(Some("gemini"), || {
+            assert_eq!(
+                Provider::from_env_default().unwrap(),
+                Some(Provider::Gemini)
+            );
+        });
+    }
+
+    #[test]
+    fn from_env_default_set_but_invalid_errors() {
+        with_env_var(Some("garbage"), || {
+            assert!(Provider::from_env_default().is_err());
+        });
     }
 }

--- a/crates/potato_type/src/prompt/interface.rs
+++ b/crates/potato_type/src/prompt/interface.rs
@@ -44,23 +44,20 @@ where
 }
 
 /// Generic prompt configuration structure for user-friendly YAML/JSON format.
-/// This format allows users to write prompts in a more intuitive way:
+///
+/// Example:
 /// ```yaml
 /// model: gemini-1.5-pro
-/// provider: Google
+/// provider: Google         # optional; falls back to POTATO_HEAD_DEFAULT_PROVIDER
 /// messages:
 ///   - "Hello ${variable1}"
-///   - "This is ${variable2}"
-/// settings:
-///   generation_config:
-///     max_output_tokens: 1024
-///     temperature: 0.7
 /// ```
 /// `messages` also accepts a single block-scalar string (YAML `|`).
 #[derive(Debug, Deserialize)]
 pub struct GenericPromptConfig {
     model: String,
-    provider: String,
+    #[serde(default)]
+    provider: Option<String>,
     #[serde(deserialize_with = "deserialize_string_or_vec")]
     messages: Vec<String>,
     #[serde(default)]
@@ -329,17 +326,17 @@ impl Prompt {
     /// # Arguments:
     /// * `message`: A single message or list of messages representing user input.
     /// * `model`: The model identifier to use for the prompt.
-    /// * `provider`: The provider to use for the prompt.
+    /// * `provider`: Optional. Defaults to env var POTATO_HEAD_DEFAULT_PROVIDER if unset.
     /// * `system_instruction`: Optional system instruction message or list of messages.
     /// * `model_settings`: Optional model settings to use for the prompt.
     /// * `output_type`: Optional output type to enforce structured output.
     #[new]
-    #[pyo3(signature = (messages, model, provider, system_instructions=None, model_settings=None, output_type=None))]
+    #[pyo3(signature = (messages, model, provider=None, system_instructions=None, model_settings=None, output_type=None))]
     pub fn new(
         py: Python<'_>,
         messages: &Bound<'_, PyAny>,
         model: &str,
-        provider: &Bound<'_, PyAny>,
+        provider: Option<&Bound<'_, PyAny>>,
         system_instructions: Option<&Bound<'_, PyAny>>,
         model_settings: Option<&Bound<'_, PyAny>>,
         output_type: Option<&Bound<'_, PyAny>>, // can be a pydantic model or one of Opsml's predefined outputs
@@ -351,7 +348,7 @@ impl Prompt {
             .transpose()?;
 
         // 2. extract provider
-        let provider = Provider::extract_provider(provider)?;
+        let provider = Provider::resolve_from_py(provider)?;
 
         // 3. Parse user messages with "user" role
         // We'll use this to figure out the type of request struct to create
@@ -822,7 +819,7 @@ impl Prompt {
         }
 
         // Parse provider string to Provider enum
-        let provider = Provider::from_string(&config.provider)?;
+        let provider = Provider::resolve(config.provider.as_deref())?;
 
         // Convert message strings to MessageNum based on provider
         let messages: Vec<MessageNum> = config

--- a/py-potato/docs/prompts.md
+++ b/py-potato/docs/prompts.md
@@ -10,12 +10,14 @@ Prompts are standardized objects for interacting with language models in Potato 
 |---------------------|--------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
 | `messages` | `Union[str | ChatMessage | MessageParam | GeminiContent]`<br>`List[Union[str | ChatMessage | MessageParam | GeminiContent]]` | The main prompt content. Can be a string, a sequence of string or be provider-specific message formats. | **Required** |
 | `model`             | `str`                                                                                        | The model to use for the prompt |**Required** |
-| `provider`          | `str`                                                                                        | The provider to use for the prompt | **Required** |
+| `provider`          | `str`                                                                                        | The provider to use for the prompt. If omitted, Potato Head reads `POTATO_HEAD_DEFAULT_PROVIDER`. | `POTATO_HEAD_DEFAULT_PROVIDER` |
 | `system_instructions`| `Optional[str | List[str]]`                                                                           | System-level instructions to include in the prompt. Can be a string or a list of strings.                                                                                                             | `None`       |
 | `model_settings`    | `Optional[ModelSettings | OpenAIChatSettings | GeminiSettings | AnthropicSettings]`                                                                              | Model settings for the prompt. If not provided, no additional model settings are used.                                                                         | `None`       |
 | `output_type`   | `Optional[Any]`                                                                                        | Specifies the output type for structured outputs. Supports Pydantic `BaseModel` classes and the PotatoHead `Score` class. The format will be parsed into a JSON schema for the LLM API.           | `None`       |
 
 ## Binding Parameters
+
+`provider` can be passed explicitly on each `Prompt`, or omitted when `POTATO_HEAD_DEFAULT_PROVIDER` is set to one of `openai`, `gemini`, `google`, `vertex`, `anthropic`, or `google_adk`. If neither an explicit provider nor that environment variable is present, prompt construction fails.
 
 One of the benefits of using the `Prompt` class is that is allows you to parameterize your messages and bind them at runtime. This is useful for creating dynamic prompts that can change based on user input or other factors.
 

--- a/py-potato/pyproject.toml
+++ b/py-potato/pyproject.toml
@@ -6,7 +6,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-version = "0.24.0"
+version = "0.26.0"
 description = ""
 authors = [
     {name = "Thorrester", email = "<support@demmlai.com>"},

--- a/py-potato/python/potato_head/_potato_head.pyi
+++ b/py-potato/python/potato_head/_potato_head.pyi
@@ -317,8 +317,8 @@ class Prompt(Generic[OutputType]):
             The user message(s) to use in the prompt.
         model (str):
             The model identifier to use (e.g., "gpt-4o", "claude-3-5-sonnet-20241022").
-        provider (Provider | str):
-            The provider to use for the prompt (e.g., "openai", "anthropic", "google").
+        provider (Provider | str | None):
+            Optional. Defaults to POTATO_HEAD_DEFAULT_PROVIDER if unset (e.g., "openai", "anthropic", "google").
         system_instructions (Optional[PromptMessage]):
             Optional system instruction(s).
         model_settings (Optional[ModelSettings | OpenAIChatSettings | GeminiSettings | AnthropicSettings]):
@@ -337,7 +337,7 @@ class Prompt(Generic[OutputType]):
         cls,
         messages: PromptMessage,
         model: str,
-        provider: Provider | str,
+        provider: Provider | str | None = None,
         system_instructions: Optional[PromptMessage] = ...,
         model_settings: Optional[ModelSettings | OpenAIChatSettings | GeminiSettings | AnthropicSettings] = ...,
         *,
@@ -348,7 +348,7 @@ class Prompt(Generic[OutputType]):
         cls,
         messages: PromptMessage,
         model: str,
-        provider: Provider | str,
+        provider: Provider | str | None = None,
         system_instructions: Optional[PromptMessage] = ...,
         model_settings: Optional[ModelSettings | OpenAIChatSettings | GeminiSettings | AnthropicSettings] = ...,
         output_type: None = ...,
@@ -987,14 +987,14 @@ class Agent:
 
     def __init__(
         self,
-        provider: Provider | str,
+        provider: Provider | str | None = None,
         system_instruction: Optional[PromptMessage] = None,
     ) -> None:
         """Create an Agent object.
 
         Args:
-            provider (Provider | str):
-                The provider to use for the agent.
+            provider (Provider | str | None):
+                Optional. Defaults to POTATO_HEAD_DEFAULT_PROVIDER if unset.
             system_instruction (Optional[PromptMessage]):
                 The system message to use for the agent.
         """

--- a/py-potato/tests/prompt/test_default_provider.py
+++ b/py-potato/tests/prompt/test_default_provider.py
@@ -1,0 +1,75 @@
+import pytest
+from potato_head import Agent, Prompt, Provider
+from potato_head.anthropic import MessageParam
+from potato_head.openai import ChatMessage
+
+ENV_VAR = "POTATO_HEAD_DEFAULT_PROVIDER"
+
+
+def test_yaml_without_provider_uses_env_var(tmp_path, monkeypatch):
+    monkeypatch.setenv(ENV_VAR, "openai")
+    yaml = tmp_path / "no_provider.yaml"
+    yaml.write_text("model: gpt-4\n" "messages:\n" '  - "Hello ${name}"\n')
+    prompt = Prompt.from_path(yaml)
+    assert prompt.provider == Provider.OpenAI
+    assert prompt.model == "gpt-4"
+
+
+def test_yaml_without_provider_no_env_var_raises(tmp_path, monkeypatch):
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    yaml = tmp_path / "no_provider.yaml"
+    yaml.write_text("model: gpt-4\n" "messages:\n" '  - "Hello"\n')
+    with pytest.raises(RuntimeError, match=ENV_VAR):
+        Prompt.from_path(yaml)
+
+
+def test_explicit_provider_overrides_env_var(tmp_path, monkeypatch):
+    monkeypatch.setenv(ENV_VAR, "anthropic")
+    yaml = tmp_path / "with_provider.yaml"
+    yaml.write_text("model: gpt-4\n" "provider: openai\n" "messages:\n" '  - "Hello"\n')
+    prompt = Prompt.from_path(yaml)
+    assert prompt.provider == Provider.OpenAI
+
+
+def test_prompt_constructor_without_provider_uses_env_var(monkeypatch):
+    monkeypatch.setenv(ENV_VAR, "anthropic")
+    prompt = Prompt(messages="Hello", model="claude-3-5-sonnet")
+    assert prompt.provider == Provider.Anthropic
+    assert isinstance(prompt.anthropic_messages[0], MessageParam)
+
+
+def test_prompt_constructor_no_provider_no_env_raises(monkeypatch):
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    with pytest.raises(RuntimeError, match=ENV_VAR):
+        Prompt(messages="Hello", model="gpt-4")
+
+
+def test_invalid_env_var_value_raises(monkeypatch):
+    monkeypatch.setenv(ENV_VAR, "not_a_provider")
+    with pytest.raises(RuntimeError):
+        Prompt(messages="Hello", model="gpt-4")
+
+
+def test_empty_env_var_treated_as_unset(monkeypatch):
+    monkeypatch.setenv(ENV_VAR, "   ")
+    with pytest.raises(RuntimeError, match=ENV_VAR):
+        Prompt(messages="Hello", model="gpt-4")
+
+
+def test_litellm_gateway_scenario(monkeypatch):
+    monkeypatch.setenv(ENV_VAR, "openai")
+    prompt = Prompt(messages="Summarize", model="claude-3-5-sonnet")
+    assert prompt.provider == Provider.OpenAI
+    assert isinstance(prompt.openai_messages[0], ChatMessage)
+
+
+def test_agent_without_provider_uses_env_var(monkeypatch):
+    monkeypatch.setenv(ENV_VAR, "openai")
+    agent = Agent()
+    assert agent is not None
+
+
+def test_agent_no_provider_no_env_raises(monkeypatch):
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    with pytest.raises(RuntimeError, match=ENV_VAR):
+        Agent()

--- a/py-potato/uv.lock
+++ b/py-potato/uv.lock
@@ -3351,7 +3351,7 @@ wheels = [
 
 [[package]]
 name = "potato-head"
-version = "0.24.0"
+version = "0.26.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Pull Request

### Short Summary

Makes `provider` optional on `Prompt(...)`, `Agent(...)`, and spec YAML by reading `POTATO_HEAD_DEFAULT_PROVIDER` from the environment when no explicit provider is given. Previously every call site had to specify it; now you can set it once per deployment and omit it everywhere.

### Context

When using Potato Head in a service that only ever talks to one LLM provider, requiring `provider=` on every `Prompt` or `Agent` is pure boilerplate. This PR pushes resolution into a central path — explicit arg wins, env var fallback, hard error if neither is set.

The core change lives in `Provider::resolve()` and `Provider::resolve_from_py()` in `potato-type`. Both Python entry points (`Prompt.__init__`, `Agent.__init__`) and the spec loader now call through these instead of `Provider::from_string()` directly. If resolution fails, the new `MissingProviderError` tells the caller exactly which env var to set:

```
No provider specified. Pass `provider=` explicitly or set the POTATO_HEAD_DEFAULT_PROVIDER env var.
```

**Before:**
```python
# Required on every call
p = Prompt(messages=..., model="gpt-4o", provider="openai")
a = Agent(provider="openai")
```

```yaml
# Required in every agent spec
provider: openai
model: gpt-4o
```

**After:**
```bash
export POTATO_HEAD_DEFAULT_PROVIDER=openai
```
```python
p = Prompt(messages=..., model="gpt-4o")   # resolves from env
a = Agent()                                  # resolves from env
```

```yaml
# provider key is now optional
model: gpt-4o
```

Explicit values still take precedence — env var is only the fallback. Whitespace-only values (both explicit and env) are treated as unset.

| File | Change |
|---|---|
| `crates/potato_type/src/lib.rs` | Adds `DEFAULT_ENV_VAR`, `from_env_default()`, `resolve()`, `resolve_from_py()` |
| `crates/potato_type/src/error.rs` | Adds `MissingProviderError` variant |
| `crates/potato_type/src/prompt/interface.rs` | `provider` field/arg → `Option<String>` / `Option<&Bound<PyAny>>`; calls `Provider::resolve()` |
| `crates/potato_agent/src/agents/agent.rs` | `provider` PyO3 arg → optional; calls `Provider::resolve_from_py()` |
| `crates/potato_spec/src/spec.rs` | `AgentSpec.provider` → `Option<String>` with `#[serde(default)]` |
| `crates/potato_spec/src/loader.rs` | Calls `Provider::resolve()` instead of `from_string()`; adds env-var-aware tests |
| `py-potato/python/potato_head/_potato_head.pyi` | `provider` stubs updated to `Provider \| str \| None = None` |
| `py-potato/tests/prompt/test_default_provider.py` | New Python tests: env fallback, explicit override, error path |
| `py-potato/docs/prompts.md` | Documents the new optional behavior |

### Is this a Breaking Change?

No. `provider` was a required argument in both Python and the spec format; it's now optional with an explicit-wins fallback. Callers that already pass `provider=` continue to work without modification. The only behavior change is that omitting `provider` no longer raises a type error at the call site — it raises `MissingProviderError` at resolution time if the env var is also absent, with a clearer message than before.
